### PR TITLE
Fix problem with branch selection and deletion of the first post in a topic

### DIFF
--- a/load-tests/src/test/resources/org/jtalks/loadtests/BaseLine.jmx
+++ b/load-tests/src/test/resources/org/jtalks/loadtests/BaseLine.jmx
@@ -20,9 +20,9 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="AUTO_TEST_SERVER" elementType="Argument">
             <stringProp name="Argument.name">AUTO_TEST_SERVER</stringProp>
-            <stringProp name="Argument.value">autotests.jtalks.org</stringProp>
+            <stringProp name="Argument.value">performance.jtalks.org</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">autotests.jtalks.org</stringProp>
+            <stringProp name="Argument.desc">Server for performance testing</stringProp>
           </elementProp>
           <elementProp name="TOPIC_ID" elementType="Argument">
             <stringProp name="Argument.name">TOPIC_ID</stringProp>

--- a/load-tests/src/test/resources/org/jtalks/loadtests/TestPlan.jmx
+++ b/load-tests/src/test/resources/org/jtalks/loadtests/TestPlan.jmx
@@ -20,9 +20,9 @@
         <collectionProp name="Arguments.arguments">
           <elementProp name="AUTO_TEST_SERVER" elementType="Argument">
             <stringProp name="Argument.name">AUTO_TEST_SERVER</stringProp>
-            <stringProp name="Argument.value">autotests.jtalks.org</stringProp>
+            <stringProp name="Argument.value">performance.jtalks.org</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
-            <stringProp name="Argument.desc">server for performance testing</stringProp>
+            <stringProp name="Argument.desc">Server for performance testing</stringProp>
           </elementProp>
           <elementProp name="TOPIC_ID" elementType="Argument">
             <stringProp name="Argument.name">TOPIC_ID</stringProp>
@@ -152,7 +152,7 @@
         <stringProp name="filename">${FILENAME}</stringProp>
       </ResultCollector>
       <hashTree/>
-      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>
         <objProp>
           <name>saveConfig</name>


### PR DESCRIPTION
Couple of problems have been fixed:
-incorrect branch number in case of gaps in sequence of branch numbers (like 1,2,4,7).
-404 error in case of deletion a first post in a topic.
