### PR TITLE
JC-2098 Maven profiles added to launch only specific load tests plan.

### DIFF
--- a/load-tests/pom.xml
+++ b/load-tests/pom.xml
@@ -49,9 +49,8 @@
           </dependency>
         </dependencies>
         <configuration>
-          <testFilesDirectory>${project.basedir}/src/test/resources</testFilesDirectory>
           <ignoreResultFailures>true</ignoreResultFailures>
-            <testResultsTimestamp>false</testResultsTimestamp>
+          <testResultsTimestamp>false</testResultsTimestamp>
         </configuration>
       </plugin>
     </plugins>
@@ -60,5 +59,59 @@
   <reporting>
     <excludeDefaults>true</excludeDefaults>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>runAllTests</id>
+	  <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.lazerycode.jmeter</groupId>
+            <artifactId>jmeter-maven-plugin</artifactId>
+            <configuration>
+              <testFilesDirectory>${project.basedir}/src/test/resources</testFilesDirectory>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>      
+    </profile>
+	<profile>
+      <id>runBaseLine</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.lazerycode.jmeter</groupId>
+            <artifactId>jmeter-maven-plugin</artifactId>
+            <configuration>
+              <testFilesDirectory>${project.basedir}/src/test/resources/org/jtalks/loadtests</testFilesDirectory>
+              <testFilesIncluded>
+                <jMeterTestFile>BaseLine.jmx</jMeterTestFile>
+              </testFilesIncluded>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>      
+    </profile>
+	<profile>
+      <id>runMainTestPlan</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.lazerycode.jmeter</groupId>
+            <artifactId>jmeter-maven-plugin</artifactId>
+            <configuration>
+              <testFilesDirectory>${project.basedir}/src/test/resources/org/jtalks/loadtests</testFilesDirectory>
+              <testFilesIncluded>
+                <jMeterTestFile>TestPlan.jmx</jMeterTestFile>
+              </testFilesIncluded>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>      
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION

Now that's possible to run only BaseLine.jmx or TestPlan.jmx with
-PrunBaseLine and -PrunMainTestPlan mvn command line options.
Default behavior is to run all test plans in the catalog, 
exactly as it was before.