### PR TITLE
Add tests for Topic and Branch notification if other user posts in Topic

### DIFF
--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicNotificationTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicNotificationTest.java
@@ -6,120 +6,281 @@ import org.jtalks.tests.jcommune.webdriver.action.Topics;
 import org.jtalks.tests.jcommune.webdriver.action.Users;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
 import org.jtalks.tests.jcommune.webdriver.entity.user.User;
+import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
+
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.mainPage;
 
 /**
  * @author Andrey Ivanov
+ * @author Andrey Surzhan
  */
 public class TopicNotificationTest {
+    public final String NOTIFICATION_BRANCH = "Notification tests";
+
+    @BeforeMethod(alwaysRun = true)
+    @Parameters({"appUrl"})
+    public void setupCase(String appUrl) throws ValidationException {
+        driver.get(appUrl);
+        mainPage.logOutIfLoggedIn(driver);
+    }
+
+
     @Test
-    public void deletingTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotification() throws Exception {
+    public void creatingTopic_ifSubscribedToBranch_shouldReceiveBranchNotification() throws Exception {
+        Topic topic = new Topic().withBranch(NOTIFICATION_BRANCH);
+
         User user = Users.signUpAndSignIn();
+        Branches.subscribe(topic.getBranch());
 
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
-        Branches.subscribe(topic.getBranch(), user);
+        Users.signUpAndSignIn();
+        Topics.createTopic(topic);
 
-        Topics.deleteByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertTopicNotificationSent(topic, user);
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, user);
+    }
+
+    /**
+     * editingTopic tests below are checking notification for subscribedUser not for topicCreator
+     * because other registrated User has no permissions to edit other Topic
+     */
+    @Test
+    public void editingTopic_shouldNotReceiveTopicAndBranchNotification() throws Exception {
+        Topic topic = new Topic().withBranch(NOTIFICATION_BRANCH);
+
+        User topicCreator = Users.signUpAndSignIn();
+        Topics.createTopic(topic);
+
+        User subscribedUser = Users.signUpAndSignIn();
+        Topics.subscribe(topic);
+        Branches.subscribe(topic.getBranch());
+
+        Users.signIn(topicCreator);
+        Topics.editPost(topic, selectedPost); //need to be implemented
+
+        Users.signIn(subscribedUser);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationsOnTopicNotSent(topic, subscribedUser);//need to be implemented
+        Notifications.assertNotificationsOnBranchNotSent(topic, subscribedUser);//need to be implemented
     }
 
     @Test
-    public void deletingTopic_ifSubscribedToBothBranchAndTopic_shouldNotReceiveBranchNotification() throws Exception {
+    public void editingTopic_ifSubscribedToBranchOnly_shouldNotReceiveBranchNotification() throws Exception {
+        User topicCreator = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+
+        User subscribedUser = Users.signUpAndSignIn();
+        Branches.subscribe(topic.getBranch());
+        Topics.unsubscribe(topic);
+
+        Users.signIn(topicCreator);
+        Topics.editPost(topic, selectedPost); //need to be implemented
+
+        Users.signIn(subscribedUser);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationsOnTopicNotSent(topic, subscribedUser);//need to be implemented
+        Notifications.assertNotificationsOnBranchNotSent(topic, subscribedUser);//need to be implemented
+    }
+
+    @Test
+    public void editingTopic_ifSubscribedToTopicOnly_shouldNotReceiveTopicNotification() throws Exception {
+        User topicCreator = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+
+        User subscribedUser = Users.signUpAndSignIn();
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
+
+        Users.signIn(topicCreator);
+        Topics.editPost(topic, selectedPost); //need to be implemented
+
+        Users.signIn(subscribedUser);
+        Notifications.assertNotificationsOnTopicNotSent(topic, subscribedUser);//need to be implemented
+        Notifications.assertNotificationsOnBranchNotSent(topic, subscribedUser);//need to be implemented
+    }
+
+
+    @Test
+    public void otherUserPostsInTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
+        User user = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.subscribe(topic.getBranch());
+
+        Users.signUpAndSignIn();
+        Topics.postAnswer(topic, topic.getBranch().getTitle());
+
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
+    }
+
+    @Test
+    public void otherUserPostsInTopic_ifSubscribedToBranchOnly_shouldReceiveBranchNotification() throws Exception {
+        User user = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(topic);
+        Branches.subscribe(topic.getBranch());
+
+        Users.signUpAndSignIn();
+        Topics.postAnswer(topic, topic.getBranch().getTitle());
+
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, user);
+    }
+
+    @Test
+    public void otherUserPostsInTopic_ifSubscribedToTopicOnly_shouldReceiveTopicNotification() throws Exception {
+        User user = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
+
+        Users.signUpAndSignIn();
+        Topics.postAnswer(topic, topic.getBranch().getTitle());
+
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
+    }
+
+
+    @Test
+    public void userPostsInOwnTopic_ifSubscribedToTopicOnly_shouldNotReceiveTopicNotification() throws Exception {
+        User user = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
+        Topics.postAnswer(topic, topic.getBranch().getTitle());
+        Notifications.assertNotificationsOnTopicNotSent(topic, user);//need to be implemented
+    }
+
+    @Test
+    public void userPostsInOwnTopic_ifSubscribedToBranchOnly_shouldNotReceiveBranchNotification() throws Exception {
+        User user = Users.signUpAndSignIn();
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(topic);
+        Branches.subscribe(topic.getBranch());
+        Topics.postAnswer(topic, topic.getBranch().getTitle());
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationsOnBranchNotSent(topic, user);//need to be implemented
+    }
+
+
+    @Test
+    public void deletingTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
-        Branches.subscribe(topic.getBranch(), user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.subscribe(topic.getBranch());
 
-        Topics.deleteByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertBranchNotificationNotSentTo(topic.getBranch(), user);
+        Users.signUpAndSignIn();
+        Topics.deleteTopic(topic);
+
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
 
     @Test
     public void deletingTopic_ifSubscribedToBranchOnly_shouldReceiveBranchNotification() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Branches.subscribe(topic.getBranch(), user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(topic);
+        Branches.subscribe(topic.getBranch());
 
-        Topics.deleteByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertBranchNotificationNotSentTo(topic.getBranch(), user);
+        Users.signUpAndSignIn();
+        Topics.deleteTopic(topic);
+
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, user);
     }
 
     @Test
     public void deletingTopic_ifSubscribedToTopicOnly_shouldReceiveTopicNotification() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
 
-        Topics.deleteByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertTopicNotificationSent(topic, user);
+        Users.signUpAndSignIn();
+        Topics.deleteTopic(topic);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
 
     @Test
-    public void deletingTopic_ifSubscribedUserDeletesTopic_shouldNotReceiveTopicNotification() throws Exception {
+    public void deletingOwnTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
         User user = Users.signUpAndSignIn();
-        Topic topic = Topics.createTopic(new Topic().withTopicStarter(user));
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
 
-        Topics.deleteByUser(topic, user);
-        Notifications.assertTopicNotificationNotSent(topic, user);
+        Topics.deleteTopic(topic);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
 
 
     @Test
-    public void movingTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotification() throws Exception {
+    public void movingTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
-        Branches.subscribe(topic.getBranch(), user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.subscribe(topic.getBranch());
 
-        Topics.moveByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertTopicNotificationSent(topic, user);
-    }
+        Users.signUpAndSignIn();
+        Topics.moveTopic(topic, "Classical Mechanics");
 
-    @Test
-    public void movingTopic_ifSubscribedToBothBranchAndTopic_shouldNotReceiveBranchNotification() throws Exception {
-        User user = Users.signUpAndSignIn();
-
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
-        Branches.subscribe(topic.getBranch(), user);
-
-        Topics.moveByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertBranchNotificationNotSentTo(topic.getBranch(), user);
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
 
     @Test
     public void movingTopic_ifSubscribedToBranchOnly_shouldReceiveBranchNotification() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Branches.subscribe(topic.getBranch(), user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(topic);
+        Branches.subscribe(topic.getBranch());
 
-        Topics.moveByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertBranchNotificationNotSentTo(topic.getBranch(), user);
+        Users.signUpAndSignIn();
+        Topics.moveTopic(topic, "Classical Mechanics");
+
+        Users.signIn(user);
+        unsubscribeIgnoringFail(Branch branch);
+        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, user);
     }
 
     @Test
     public void movingTopic_ifSubscribedToTopicOnly_shouldReceiveTopicNotification() throws Exception {
         User user = Users.signUpAndSignIn();
 
-        Topic topic = Topics.createTopic(new Topic());
-        Topics.subscribe(topic, user);
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
 
-        Topics.moveByUser(topic, Users.signUpAndSignIn());
-        Notifications.assertTopicNotificationSent(topic, user);
+        Users.signUpAndSignIn();
+        Topics.moveTopic(topic, "Classical Mechanics");
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
 
     @Test
-    public void movingTopic_ifSubscribedUserMoveTopic_shouldNotReceiveTopicNotification() throws Exception {
+    public void movingOwnTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
         User user = Users.signUpAndSignIn();
-        Topic topic = Topics.createTopic(new Topic().withTopicStarter(user));
+        Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
+        Topics.subscribe(topic);
+        Branches.unsubscribe(topic.getBranch());
 
-        Topics.moveByUser(topic, user);
-        Notifications.assertTopicNotificationNotSent(topic, user);
+        Topics.moveTopic(topic);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, user);
     }
+
 }


### PR DESCRIPTION
 Add tests for Topic and Branch notification if other user posts in Topic

Updated existed tests with additional steps and specified creating topic
in specific branch
Added following tests:

 - Test checks that Topic Notification is received if subscribed User has
   Branch subscription and other User has created topic in that Branch
 - Test checks that Topic Notification is received if subscribed User has
   Topic and Branch subscription and other User has edited first posted in that Topic
 - Test checks that Branch Notification is not received if subscribed User has
   Topic and Branch subscription and other User has edited first posted in that Topic
 - Test checks that Branch Notification is received if subscribed User has
   Branch subscription only and other User has edited first posted in that Topic
 - Test checks that Topic Notification is received if subscribed User has
   Topic and Branch subscription and other User has posted in that Topic
 - Test checks that Branch Notification is not received if subscribed User
   has Topic and Branch subscription and other User has posted in that Topic
 - Test checks that Branch Notification is received if subscribed User has
   Branch subscription only and other User has posted in that Topic
 - Test checks that Topic Notification is received if subscribed User has
   Topic subscription only and other User has posted in that Topic
 - Test checks that Topic Notification is not received if subscribed User
   has posted in that Topic
 - Test checks that Branch Notification is not received if subscribed
   User has posted in that Topic