### PR TITLE
Big code refactoring and Notifications web-driver added

### DIFF
--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/CodeReviewNotificationTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/CodeReviewNotificationTest.java
@@ -32,7 +32,7 @@ public class CodeReviewNotificationTest {
     }
 
     @Test
-    public void autosubscribe_codeReviewStarterAutomaticallySubscribes() throws Exception{
+    public void autosubscribe_codeReviewStarterAutomaticallySubscribes() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
 
@@ -40,11 +40,10 @@ public class CodeReviewNotificationTest {
     }
 
     @Test
-    public void  autosubscribe_codeReviewCommentatorAutomaticallySubscribes() throws Exception{
+    public void autosubscribe_codeReviewCommentatorAutomaticallySubscribes() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
 
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        Users.logout();
 
         User codeReviewCommentator = Users.signUpAndSignIn();
         Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
@@ -53,42 +52,35 @@ public class CodeReviewNotificationTest {
     }
 
     @Test
-    public void createCodeReview_UserSubscribedToBranchReceivesBranchNotificationOnly() throws  Exception{
+    public void createCodeReview_userSubscribedToBranch_receivesBranchNotificationOnly() throws Exception {
         CodeReview codeReview = new CodeReview().withBranch(NOTIFICATION_BRANCH);
 
         User branchSubscriber = Users.signUpAndSignIn();
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
 
-        User codeReviewStarter = Users.signUpAndSignIn();
+        Users.signUpAndSignIn();
         Topics.createCodeReview(codeReview);
-        Users.logout();
 
-        Users.signIn(branchSubscriber);
+        Users.logOutAndSignIn(branchSubscriber);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, branchSubscriber);
-        Notifications.assertNotificationOnBranchSent(codeReview.getBranch(), branchSubscriber);
-
+        Notifications.assertNotificationOnTopicNotSentBranchSent(codeReview, branchSubscriber);
     }
 
     @Test
-    public void createCodeReview_UserNotSubscribedToBranchDoNotReciveNotifications() throws  Exception{
+    public void createCodeReview_userNotSubscribedToBranch_doNotReceiveNotifications() throws Exception {
         CodeReview codeReview = new CodeReview().withBranch(NOTIFICATION_BRANCH);
 
-        User branchSubscriber = Users.signUpAndSignIn();
-        Users.logout();
+        User testUser = Users.signUpAndSignIn();
 
         User codeReviewStarter = Users.signUpAndSignIn();
         Topics.createCodeReview(codeReview);
-        Users.logout();
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), branchSubscriber);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, branchSubscriber);
+        Notifications.assertNotificationsNotSent(codeReview, testUser);
     }
 
     @Test
-    public void createCodeReview_UserSubscribedToBranchDoNotReciveNotificationsIfCreatedCodeReviewHimself() throws  Exception{
+    public void createCodeReview_userSubscribedToBranch_doNotReceiveNotificationsIfCreatedCodeReviewHimself() throws Exception {
         CodeReview codeReview = new CodeReview().withBranch(NOTIFICATION_BRANCH);
 
         User branchSubscriber = Users.signUpAndSignIn();
@@ -96,384 +88,310 @@ public class CodeReviewNotificationTest {
         Topics.createCodeReview(codeReview);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), branchSubscriber);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, branchSubscriber);
+        Notifications.assertNotificationsNotSent(codeReview, branchSubscriber);
     }
 
     @Test
-    public void addCommentToCodeReview_UserSubscribedToCodeReviewOnlyReceivesCodeReviewNotificationOnly() throws Exception {
+    public void addCommentToCodeReview_userSubscribedToCodeReviewOnly_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Users.logout();
 
         User topicCommentator = Users.signUpAndSignIn();
         Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
 
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void addCommentToCodeReview_UserSubscribedToBranchOnlyDoNotReceiveNotifications() throws Exception{
+    public void addCommentToCodeReview_userSubscribedToBranchOnly_doNotReceiveNotifications() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Topics.unsubscribe(codeReview);
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
-
-        User topicCommentator = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
-        Users.logout();
-
-        Users.signIn(codeReviewStarter);
-        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
-
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-
-    }
-
-    @Test
-    public void addCommentToCodeReview_UserSubscribedBothToBranchAndCodReviewReceivesCodeReviewNotificationOnly() throws Exception{
-        User codeReviewStarter = Users.signUpAndSignIn();
-        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Branches.subscribe(codeReview.getBranch());
-        Users.logout();
-
-        User topicCommentator = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
-        Users.logout();
-
-        Users.signIn(codeReviewStarter);
-        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
-
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-    }
-
-    @Test
-    public void addCommentToCodeReview_UserSubscribedToCodeReviewDoNotReceiveNotificationsAboutHisOwnComments() throws Exception{
-        User codeReviewStarter = Users.signUpAndSignIn();
-        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
-
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-    }
-
-    @Test
-    public void addCommentToCodeReview_UnsubscribedUserDoNotReceiveNotifications() throws Exception{
-        User codeReviewStarter = Users.signUpAndSignIn();
-        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        Topics.unsubscribe(codeReview);
-        Users.logout();
 
         User topicCommentator = Users.signUpAndSignIn();
         Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-    }
-
-    @Test
-    public void deleteCodeReview_UserSubscribedToCodeReviewOnlyReceivesCodeReviewNotificationOnly() throws Exception {
-        User codeReviewStarter = Users.signUpAndSignIn();
-        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Users.logout();
-
-        User codeReviewDeleter = Users.signUpAndSignIn();
-        Topics.deleteTopic(codeReview);
-
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-    }
-
-    @Test
-    public void deleteCodeReview_UserSubscribedToBranchOnlyReceivesBranchNotificationOnly() throws Exception{
-        User codeReviewStarter = Users.signUpAndSignIn();
-        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
-        Topics.unsubscribe(codeReview);
-        Branches.subscribe(codeReview.getBranch());
-        Users.logout();
-
-        User codeReviewDeleter = Users.signUpAndSignIn();
-        Topics.deleteTopic(codeReview);
-        Users.logout();
-
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationOnBranchSent(codeReview.getBranch(), codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReview_UserSubscribedBothToBranchAndCodeReviewReceivesCodeReviewNotificationOnly() throws Exception{
+    public void addCommentToCodeReview_userSubscribedBothToBranchAndCodeReview_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
+
+        User topicCommentator = Users.signUpAndSignIn();
+        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
+
+        Users.logOutAndSignIn(codeReviewStarter);
+        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
+
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
+    }
+
+    @Test
+    public void addCommentToCodeReview_userSubscribedToCodeReview_doNotReceiveNotificationsAboutHisOwnComments() throws Exception {
+        User codeReviewStarter = Users.signUpAndSignIn();
+        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
+        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
+        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
+
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
+    }
+
+    @Test
+    public void addCommentToCodeReview_unsubscribedUser_doNotReceiveNotifications() throws Exception {
+        User codeReviewStarter = Users.signUpAndSignIn();
+        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(codeReview);
+
+        User topicCommentator = Users.signUpAndSignIn();
+        Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
+
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
+    }
+
+    @Test
+    public void deleteCodeReview_userSubscribedToCodeReviewOnly_receivesCodeReviewNotificationOnly() throws Exception {
+        User codeReviewStarter = Users.signUpAndSignIn();
+        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
+        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
 
         User codeReviewDeleter = Users.signUpAndSignIn();
         Topics.deleteTopic(codeReview);
 
-        Users.signIn(codeReviewStarter);
-        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
-
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReview_UserSubscribedToCodeReviewDoNotReceiveNotificationIfHeHimselfDeletedCodeReview() throws Exception{
+    public void deleteCodeReview_userSubscribedToBranchOnly_receivesBranchNotificationOnly() throws Exception {
+        User codeReviewStarter = Users.signUpAndSignIn();
+        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
+        Topics.unsubscribe(codeReview);
+        Branches.subscribe(codeReview.getBranch());
+
+        User codeReviewDeleter = Users.signUpAndSignIn();
+        Topics.deleteTopic(codeReview);
+
+        Users.logOutAndSignIn(codeReviewStarter);
+        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
+
+        Notifications.assertNotificationOnTopicNotSentBranchSent(codeReview, codeReviewStarter);
+    }
+
+    @Test
+    public void deleteCodeReview_userSubscribedBothToBranchAndCodeReview_receivesCodeReviewNotificationOnly() throws Exception {
+        User codeReviewStarter = Users.signUpAndSignIn();
+        CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
+        //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
+        Branches.subscribe(codeReview.getBranch());
+
+        User codeReviewDeleter = Users.signUpAndSignIn();
+        Topics.deleteTopic(codeReview);
+
+        Users.logOutAndSignIn(codeReviewStarter);
+        Branches.unsubscribeIgnoringFail(codeReview.getBranch());
+
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
+    }
+
+    @Test
+    public void deleteCodeReview_userSubscribedToCodeReview_doNotReceiveNotificationIfHeDeletedCodeReview() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
         Topics.deleteTopic(codeReview);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReview_UserSubscribedToBranchDoNotReceiveNotificationIfHeHimselfDeletedCodeReview() throws Exception{
+    public void deleteCodeReview_userSubscribedToBranch_doNotReceiveNotificationIfHeDeletedCodeReview() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Branches.subscribe(codeReview.getBranch());
         Topics.unsubscribe(codeReview);
+
         Topics.deleteTopic(codeReview);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReview_UnsubscribedUserDoNotReceiveNotifications() throws Exception{
+    public void deleteCodeReview_unsubscribedUser_doNotReceiveNotifications() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Topics.unsubscribe(codeReview);
-        Users.logout();
 
         User codeReviewDeleter = Users.signUpAndSignIn();
         Topics.deleteTopic(codeReview);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void moveCodeReview_UserSubscribedToCodeReviewOnlyReceivesCodeReviewNotificationOnly() throws Exception{
+    public void moveCodeReview_userSubscribedToCodeReviewOnly_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Branch oldBranch = codeReview.getBranch();
-        Users.logout();
 
         User codeReviewMover = Users.signUpAndSignIn();
         Topics.moveTopic(codeReview, BRANCH_NAME_TO_MOVE_TOPIC_IN);
 
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(oldBranch, codeReviewStarter);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void moveCodeReview_UserSubscribedToBranchOnlyDoNotReceiveNotification() throws Exception{
+    public void moveCodeReview_userSubscribedToBranchOnly_doNotReceiveNotification() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Topics.unsubscribe(codeReview);
         Branches.subscribe(codeReview.getBranch());
+
         Branch oldBranch = codeReview.getBranch();
-        Users.logout();
 
         User codeReviewMover = Users.signUpAndSignIn();
         Topics.moveTopic(codeReview, BRANCH_NAME_TO_MOVE_TOPIC_IN);
-        Users.logout();
 
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(oldBranch);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(oldBranch, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void moveCodeReview_UserSubscribedBothToBranchAndCodeReviewReceivesCodeReviewNotificationOnly() throws Exception{
+    public void moveCodeReview_userSubscribedBothToBranchAndCodeReview_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
         Branches.subscribe(codeReview.getBranch());
         Branch oldBranch = codeReview.getBranch();
-        Users.logout();
 
         User codeReviewMover = Users.signUpAndSignIn();
         Topics.moveTopic(codeReview, BRANCH_NAME_TO_MOVE_TOPIC_IN);
-        Users.logout();
 
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(oldBranch);
 
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(oldBranch, codeReviewStarter);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void moveCodeReview_UserSubscribedToCodeReviewDoNotReceiveNotificationIfHeHimselfMovedCodeReview() throws Exception{
+    public void moveCodeReview_userSubscribedToCodeReview_doNotReceiveNotificationIfHeMovedCodeReview() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Branch oldBranch = codeReview.getBranch();
         Topics.moveTopic(codeReview, BRANCH_NAME_TO_MOVE_TOPIC_IN);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(oldBranch, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void moveCodeReview_UnsubscribedUserDoNotReceiveNotifications() throws Exception{
+    public void moveCodeReview_unsubscribedUser_doNotReceiveNotifications() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Branch oldBranch = codeReview.getBranch();
         Topics.unsubscribe(codeReview);
-        Users.logout();
 
         User codeReviewMover = Users.signUpAndSignIn();
         Topics.moveTopic(codeReview, BRANCH_NAME_TO_MOVE_TOPIC_IN);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(oldBranch, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void editCodeReviewComment_UserSubscribedToCodeReviewOnlyDoNotReciveNotification() throws Exception {
+    public void editCodeReviewComment_userSubscribedToCodeReviewOnly_doNotReceiveNotification() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Users.logout();
 
         User codeReviewCommentEditor = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.editCodeReviewComment(codeReview, codeReviewComment);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void editCodeReviewComment_UserSubscribedToBranchOnlyDoNotReciveNotification() throws Exception {
+    public void editCodeReviewComment_userSubscribedToBranchOnly_doNotReceiveNotification() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Topics.unsubscribe(codeReview);
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
 
         User codeReviewCommentEditor = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.editCodeReviewComment(codeReview, codeReviewComment);
-        Users.logout();
 
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReviewComment_UserSubscribedToCodeReviewOnlyReceivesCodeReviewNotificationOnly() throws Exception {
+    public void deleteCodeReviewComment_userSubscribedToCodeReviewOnly_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Users.logout();
 
         User codeReviewCommentDeleter = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.deleteCodeReviewComment(codeReview, codeReviewComment);
 
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReviewComment_UserSubscribedToBranchOnlyDoNotReceiveNotifications() throws Exception{
+    public void deleteCodeReviewComment_userSubscribedToBranchOnly_doNotReceiveNotifications() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         Topics.unsubscribe(codeReview);
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
 
         User codeReviewCommentDeleter = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.deleteCodeReviewComment(codeReview, codeReviewComment);
-        Users.logout();
 
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReviewComment_UserSubscribedBothToBranchAndCodeReviewReceivesCodeReviewNotificationOnly() throws Exception{
+    public void deleteCodeReviewComment_userSubscribedBothToBranchAndCodeReview_receivesCodeReviewNotificationOnly() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
         Branches.subscribe(codeReview.getBranch());
-        Users.logout();
 
         User codeReviewCommentDeleter = Users.signUpAndSignIn();
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.deleteCodeReviewComment(codeReview, codeReviewComment);
-        Users.logout();
 
-        Users.signIn(codeReviewStarter);
+        Users.logOutAndSignIn(codeReviewStarter);
         Branches.unsubscribeIgnoringFail(codeReview.getBranch());
 
-        Notifications.assertNotificationOnTopicSent(codeReview, codeReviewStarter);
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
+        Notifications.assertNotificationOnTopicSentBranchNotSent(codeReview, codeReviewStarter);
     }
 
     @Test
-    public void deleteCodeReviewComment_UserSubscribedToCodeReviewOnlyDoNotReceiveNotificationsIfHimselfDeletesComment() throws Exception {
+    public void deleteCodeReviewComment_userSubscribedToCodeReviewOnly_doNotReceiveNotificationsIfHeDeletesComment() throws Exception {
         User codeReviewStarter = Users.signUpAndSignIn();
         CodeReview codeReview = Topics.createCodeReview(new CodeReview().withBranch(NOTIFICATION_BRANCH));
         //We do not subscribe codeReviewStarter to topic explicitly, because he is automatically subscribed
-        Topics.leaveCodeReviewComment(codeReview);
-        CodeReviewComment codeReviewComment = codeReview.getComments().get(0);
-        // two lines above should be replaced by following:
-        // CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview);
+        CodeReviewComment codeReviewComment = Topics.leaveCodeReviewComment(codeReview, new CodeReviewComment());
         Topics.deleteCodeReviewComment(codeReview, codeReviewComment);
 
-        Notifications.assertNotificationsOnBranchNotSent(codeReview.getBranch(), codeReviewStarter);
-        Notifications.assertNotificationsOnTopicNotSent(codeReview, codeReviewStarter);
+        Notifications.assertNotificationsNotSent(codeReview, codeReviewStarter);
     }
-
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/LastReadPostTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/LastReadPostTest.java
@@ -43,7 +43,7 @@ public class LastReadPostTest {
         Topics.createTopic(newTopic);
 
         User userThatWantsToSeeNewMessages = Users.signUpAndSignIn();
-        Topics.postAnswer(newTopic, newTopic.getBranch().getTitle());
+        Topics.postAnswer(newTopic);
 
         Topics.assertHasNewMessages(newTopic, userThatWantsToSeeNewMessages);
     }
@@ -55,7 +55,7 @@ public class LastReadPostTest {
         mainPage.clickLogout();
 
         User userThatWantsToSeeNewMessages = Users.signUpAndSignIn();
-        Branches.openBranch(newTopic.getBranch().getTitle());
+        Branches.openBranch(newTopic.getBranch());
         Branches.clickMarkAllAsRead();
 
         Topics.assertHasNoNewMessages(newTopic, userThatWantsToSeeNewMessages);
@@ -65,8 +65,8 @@ public class LastReadPostTest {
     public void givenTopicContainsUnreadPost_afterThatPostIsRemoved_topicBecomesRead() throws Exception {
         Users.signUpAndSignIn();
         Topic newTopic = Topics.createTopic(new Topic());
-        Topics.postAnswer(newTopic, newTopic.getBranch().getTitle());
-        Topics.deleteAnswer(newTopic, newTopic.getLastPost());
+        Topics.postAnswer(newTopic);
+        Topics.deletePost(newTopic, newTopic.getLastPost());
 
         User userThatWantsToSeeNewMessages = Users.signUpAndSignIn();
 
@@ -80,7 +80,7 @@ public class LastReadPostTest {
         newTopic.withTopicStarter(userThatWantsToSeeNewMessages);
         Topics.createTopic(newTopic);
 
-        Branches.openBranch(newTopic.getBranch().getTitle());
+        Branches.openBranch(newTopic.getBranch());
         Branches.clickMarkAllAsRead();
 
         Topics.assertHasNoNewMessages(newTopic, userThatWantsToSeeNewMessages);
@@ -92,7 +92,7 @@ public class LastReadPostTest {
         Topic newTopic = Topics.createTopic(new Topic());
         mainPage.clickLogout();
 
-        Branches.openBranch(newTopic.getBranch().getTitle());
+        Branches.openBranch(newTopic.getBranch());
         Branches.clickMarkAllAsRead();
 
         //null should be changed to anonymous user representation
@@ -105,9 +105,9 @@ public class LastReadPostTest {
         Users.signUpAndSignIn();
         Topic newTopic = Topics.createTopic(new Topic());
 
-        Branches.openBranch(newTopic.getBranch().getTitle());
+        Branches.openBranch(newTopic.getBranch());
         for (int i = 0; i < 2 * postsCountOnPage; ++i) {
-            Topics.postAnswer(newTopic, newTopic.getBranch().getTitle());
+            Topics.postAnswer(newTopic);
         }
 
         mainPage.clickLogout();
@@ -116,7 +116,7 @@ public class LastReadPostTest {
         Topics.openTopicInCurrentBranch(1, newTopic.getTitle());
 
         //Check, do we need to open branch page.
-        Branches.openBranch(newTopic.getBranch().getTitle());
+        Branches.openBranch(newTopic.getBranch());
         Topics.assertHasNewMessages(newTopic, userThatWantsToSeeNewMessages);
     }
 

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicNotificationTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicNotificationTest.java
@@ -22,6 +22,7 @@ import static org.jtalks.tests.jcommune.webdriver.page.Pages.mainPage;
  * @author Pancheshenko Andrey
  */
 public class TopicNotificationTest {
+
     private final String NOTIFICATION_BRANCH = "Notification tests";
     private final String BRANCH_NAME_TO_MOVE_TOPIC_IN = "Classical Mechanics";
 
@@ -35,7 +36,7 @@ public class TopicNotificationTest {
     // create topic
 
     @Test
-    public void topicCreatedByOther_ifSubscribedToBranch_shouldReceiveBranchNotificationNotTopic() throws Exception {
+    public void topicCreatedByOther_ifSubscribedToBranch_shouldReceiveBranchNotificationOnly() throws Exception {
         Topic topic = new Topic().withBranch(NOTIFICATION_BRANCH);
 
         User subscriber = Users.signUpAndSignIn();
@@ -46,7 +47,9 @@ public class TopicNotificationTest {
 
         Users.logOutAndSignIn(subscriber);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
-        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, subscriber);
+
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationSent(subscriber);
     }
 
     @Test
@@ -59,7 +62,8 @@ public class TopicNotificationTest {
         Users.signUpAndSignIn();
         Topics.createTopic(topic);
 
-        Notifications.assertNotificationsNotSent(topic, subscriber);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -71,7 +75,9 @@ public class TopicNotificationTest {
         Topics.createTopic(topic);
 
         Branches.unsubscribeIgnoringFail(topic.getBranch());
-        Notifications.assertNotificationsNotSent(topic, creator);
+
+        Notifications.assertTopicNotificationNotSent(creator);
+        Notifications.assertBranchNotificationNotSent(creator);
     }
 
     // edit topic
@@ -91,7 +97,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(subscriber);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, subscriber);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -109,7 +116,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(subscriber);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, subscriber);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -124,7 +132,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Topics.editPost(topic, topic.getFirstPost());
 
-        Notifications.assertNotificationsNotSent(topic, subscriber);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -138,13 +147,14 @@ public class TopicNotificationTest {
 
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     // add post
 
     @Test
-    public void otherUserPostsInTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void otherUserPostsInTopic_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
         Topics.subscribe(topic);
@@ -156,7 +166,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
@@ -172,11 +183,12 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     @Test
-    public void otherUserPostsInTopic_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void otherUserPostsInTopic_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
         Topics.subscribe(topic);
@@ -185,7 +197,8 @@ public class TopicNotificationTest {
         Users.signUpAndSignIn();
         Topics.postAnswer(topic);
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
@@ -197,7 +210,8 @@ public class TopicNotificationTest {
         Topics.postAnswer(topic);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     @Test
@@ -208,7 +222,8 @@ public class TopicNotificationTest {
         Branches.unsubscribe(topic.getBranch());
         Topics.postAnswer(topic);
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     @Test
@@ -220,7 +235,8 @@ public class TopicNotificationTest {
         Topics.postAnswer(topic);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     // edit subscriber's post
@@ -230,7 +246,7 @@ public class TopicNotificationTest {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
-        User subscribedUser = Users.signUpAndSignIn();
+        User subscriber = Users.signUpAndSignIn();
         Post postToEdit = Topics.postAnswer(topic);
         Topics.subscribe(topic);
         Branches.subscribe(topic.getBranch());
@@ -238,10 +254,11 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Topics.editPost(topic, postToEdit);
 
-        Users.logOutAndSignIn(subscribedUser);
+        Users.logOutAndSignIn(subscriber);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, subscribedUser);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -249,7 +266,7 @@ public class TopicNotificationTest {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
-        User subscribedUser = Users.signUpAndSignIn();
+        User subscriber = Users.signUpAndSignIn();
         Post postToEdit = Topics.postAnswer(topic);
         Topics.unsubscribe(topic);
         Branches.subscribe(topic.getBranch());
@@ -257,10 +274,11 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Topics.editPost(topic, postToEdit);
 
-        Users.logOutAndSignIn(subscribedUser);
+        Users.logOutAndSignIn(subscriber);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, subscribedUser);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -268,7 +286,7 @@ public class TopicNotificationTest {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
-        User subscribedUser = Users.signUpAndSignIn();
+        User subscriber = Users.signUpAndSignIn();
         Post postToEdit = Topics.postAnswer(topic);
         Topics.subscribe(topic);
         Branches.unsubscribe(topic.getBranch());
@@ -276,7 +294,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Topics.editPost(topic, postToEdit);
 
-        Notifications.assertNotificationsNotSent(topic, subscribedUser);
+        Notifications.assertTopicNotificationNotSent(subscriber);
+        Notifications.assertBranchNotificationNotSent(subscriber);
     }
 
     @Test
@@ -293,7 +312,8 @@ public class TopicNotificationTest {
         Topics.editPost(topic, postToEdit);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     // delete post
@@ -302,7 +322,7 @@ public class TopicNotificationTest {
     // delete topic
 
     @Test (enabled = false) // bug: receives branch notification
-    public void topicDeletedByOther_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void topicDeletedByOther_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
@@ -315,11 +335,12 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
-    public void topicDeletedByOther_ifSubscribedToBranchOnly_shouldReceiveBranchNotificationNotTopic() throws Exception {
+    public void topicDeletedByOther_ifSubscribedToBranchOnly_shouldReceiveBranchNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
@@ -332,11 +353,12 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationOnTopicNotSentBranchSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationSent(topicCreator);
     }
 
     @Test (enabled = false) // bug: receives branch notification
-    public void topicDeletedByOther_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void topicDeletedByOther_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
@@ -346,7 +368,8 @@ public class TopicNotificationTest {
         Users.signUpAndSignIn();
         Topics.deleteTopic(topic);
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
@@ -360,13 +383,14 @@ public class TopicNotificationTest {
         Topics.deleteTopic(topic);
         Branches.unsubscribeIgnoringFail(topic.getBranch());
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     // move topic
 
     @Test (enabled = false) // bug: receives branch notification
-    public void topicMovedByOther_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void topicMovedByOther_ifSubscribedToBothBranchAndTopic_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
@@ -379,7 +403,8 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(new Branch(NOTIFICATION_BRANCH));
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
@@ -396,11 +421,12 @@ public class TopicNotificationTest {
         Users.logOutAndSignIn(topicCreator);
         Branches.unsubscribeIgnoringFail(new Branch(NOTIFICATION_BRANCH));
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 
     @Test (enabled = false) // bug: receives branch notification
-    public void topicMovedByOther_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationNotBranch() throws Exception {
+    public void topicMovedByOther_ifSubscribedToTopicOnly_shouldReceiveTopicNotificationOnly() throws Exception {
         User topicCreator = Users.signUpAndSignIn();
         Topic topic = Topics.createTopic(new Topic().withBranch(NOTIFICATION_BRANCH));
 
@@ -411,7 +437,8 @@ public class TopicNotificationTest {
 
         Topics.moveTopic(topic, BRANCH_NAME_TO_MOVE_TOPIC_IN);
 
-        Notifications.assertNotificationOnTopicSentBranchNotSent(topic, topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
+        Notifications.assertTopicNotificationSent(topicCreator);
     }
 
     @Test
@@ -425,6 +452,7 @@ public class TopicNotificationTest {
         Topics.moveTopic(topic, BRANCH_NAME_TO_MOVE_TOPIC_IN);
         Branches.unsubscribeIgnoringFail(new Branch(NOTIFICATION_BRANCH));
 
-        Notifications.assertNotificationsNotSent(topic, topicCreator);
+        Notifications.assertTopicNotificationNotSent(topicCreator);
+        Notifications.assertBranchNotificationNotSent(topicCreator);
     }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicTest.java
@@ -156,7 +156,7 @@ public class TopicTest {
         Users.signUpAndSignIn();
         Topic topic = new Topic();
         Topics.createTopic(topic);
-        Topics.postAnswer(topic, topic.getBranch().getTitle());
+        Topics.postAnswer(topic);
     }
 
     @Test(groups = "ui-tests", expectedExceptions = PermissionsDeniedException.class)

--- a/html-w3c-tests/src/test/java/org/jtalks/tests/jcommune/PagesW3CValidationTest.java
+++ b/html-w3c-tests/src/test/java/org/jtalks/tests/jcommune/PagesW3CValidationTest.java
@@ -51,22 +51,22 @@ public class PagesW3CValidationTest {
     }
 
     @Test
-    public void topicPage_Test() throws Exception {
-        topicPage.goToTopicPage();
+    public void branchPage_Test() throws Exception {
+        Topics.goToBranchPage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
 
     @Test
     public void topicCreatePage_Test() throws Exception {
-        topicPage.goToTopicCreatePage();
+        Topics.goToTopicCreatePage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
 
     @Test
     public void codeReviewCreatePage_Test() throws Exception {
-        topicPage.goToReviewCreatePage();
+        Topics.goToReviewCreatePage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
@@ -78,7 +78,7 @@ public class PagesW3CValidationTest {
         User user = Users.signUpAndSignIn();
         topic.withTopicStarter(user);
         Topics.createTopic(topic);
-        Topics.postAnswer(topic, branchTitle);
+        Topics.postAnswer(topic);
         String pageSource = getPageSource();
         validatePage(pageSource);
     }

--- a/html-w3c-tests/src/test/java/org/jtalks/tests/jcommune/PagesW3CValidationTest.java
+++ b/html-w3c-tests/src/test/java/org/jtalks/tests/jcommune/PagesW3CValidationTest.java
@@ -52,31 +52,29 @@ public class PagesW3CValidationTest {
 
     @Test
     public void branchPage_Test() throws Exception {
-        Topics.goToBranchPage();
+        Topics.w3cGoToBranchPage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
 
     @Test
     public void topicCreatePage_Test() throws Exception {
-        Topics.goToTopicCreatePage();
+        Topics.w3cGoToTopicCreatePage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
 
     @Test
     public void codeReviewCreatePage_Test() throws Exception {
-        Topics.goToReviewCreatePage();
+        Topics.w3cGoToReviewCreatePage();
         String pageSource = getPageSource();
         validatePage(pageSource);
     }
 
     @Test
     public void postPage_Test() throws Exception {
-        Topic topic = new Topic(randomAlphanumeric(40), randomAlphanumeric(100));
-        String branchTitle = "TestBranch";
-        User user = Users.signUpAndSignIn();
-        topic.withTopicStarter(user);
+        Users.signUpAndSignIn();
+        Topic topic = new Topic();
         Topics.createTopic(topic);
         Topics.postAnswer(topic);
         String pageSource = getPageSource();

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Branches.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Branches.java
@@ -2,8 +2,8 @@ package org.jtalks.tests.jcommune.webdriver.action;
 
 import org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig;
 import org.jtalks.tests.jcommune.webdriver.entity.branch.Branch;
-import org.jtalks.tests.jcommune.webdriver.entity.user.User;
 import org.jtalks.tests.jcommune.webdriver.exceptions.CouldNotOpenPageException;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import ru.yandex.qatools.allure.annotations.Step;
 
@@ -11,47 +11,105 @@ import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
 import static org.jtalks.tests.jcommune.webdriver.page.Pages.branchPage;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.*;
+
 import static org.testng.Assert.assertTrue;
 
 /**
  * @author stanislav bashkirtsev
  * @author andrey ivanov
+ * @author pancheshenko andrey
  */
 public class Branches {
     @Step
-    public static void openBranch(String branchTitle) throws CouldNotOpenPageException {
-        info("Opening branch: [" + branchTitle + "]");
-        WebElement branch = branchPage.findBranch(branchTitle);
+    public static void openBranch(Branch branch) throws CouldNotOpenPageException {
+        if (!branchPage.isUserInsideCorrectBranch(branch.getTitle())) {
+            info("User is not browsing the required branch. Opening it from the main page.");
+            if (!JCommuneSeleniumConfig.driver.getCurrentUrl().equals(JCommuneSeleniumConfig.getAppUrl())) {
+                gotoMainPage();
+            }
+            gotoBranch(branch.getTitle());
+        } else {
+            if (JCommuneSeleniumConfig.driver.getCurrentUrl().contains("/topics/")) {
+                info("User is inside some topic at the required branch. Opening branch by link in the breadcrumbs.");
+                postPage.returnToBranchPage();
+            }
+        }
+    }
+
+    @Step
+    public static void subscribe(Branch branch) throws NoSuchElementException {
+        openBranch(branch);
+        try {
+            if (branchPage.isUserAlreadySubscribed()) {
+                info("User already subscribed on the branch");
+            } else {
+                info("Clicking subscribe button");
+                branchPage.getSubscribeButton().click();
+            }
+        } catch (NoSuchElementException e) {
+            info("Subscribe button was not found");
+            throw new NoSuchElementException("Subscribe button was not found", e);
+        }
+    }
+
+    @Step
+    public static void unsubscribe(Branch branch) throws NoSuchElementException {
+        openBranch(branch);
+        try {
+            if (branchPage.isUserAlreadySubscribed()) {
+                info("User is subscribed on the branch. Clicking unsubscribe button");
+                branchPage.getSubscribeButton().click();
+            } else {
+                info("User isn't subscribed on the branch");
+            }
+        } catch (NoSuchElementException e) {
+            info("Subscribe button was not found");
+            throw new NoSuchElementException("Subscribe button was not found", e);
+        }
+    }
+
+    /**
+     * This method is created for cleaning up the consequences of branch subscription.
+     * This is a "sanitary" method that wouldn't affect the overall test result in case the method fails.
+     *
+     * @param branch
+     */
+    public static void unsubscribeIgnoringFail(Branch branch) {
+        try {
+            unsubscribe(branch);
+        } catch (NoSuchElementException e) {
+            info("Branch unsubscribe NoSuchElementException: " + e);
+        } catch (CouldNotOpenPageException e) {
+            info("Branch unsubscribe CouldNotOpenPageException: " + e);
+        }
+    }
+
+    public static void gotoMainPage() {
+        mainPage.clickForumsTitle();
+    }
+
+    private static void gotoBranch(String branchTitle) throws CouldNotOpenPageException {
+        info("Start looking for branch: [" + branchTitle + "] in the main page");
+        WebElement branch = sectionPage.findBranch(branchTitle);
         if (branch != null) {
             info("The branch was found, clicking on it..");
             branch.click();
         } else {
             info(String.format("No branch found with name [%s]", branchTitle));
-            info(String.format("There were these branches available: %s", Branch.fromForm(branchPage.getBranches())));
+            info(String.format("There were these branches available: %s", Branch.fromForm(sectionPage.getBranches())));
             throw new CouldNotOpenPageException(branchTitle);
         }
     }
 
-    public static void clickMarkAllAsRead() {
-        throw new UnsupportedOperationException("This is just stub method. Implementation will be created in the future");
-    }
-
-    public static void subscribe(Branch branch) {
-        throw new UnsupportedOperationException("To be implemented");
-    }
-
-    public static void unsubscribe(Branch branch) {
-        throw new UnsupportedOperationException("To be implemented");
-    }
-
-    public static void unsubscribeIgnoringFail(Branch branch){
-        throw new UnsupportedOperationException("To be implemented");
-    }
-
     public static Branch userIsViewingRandomBranch() {
-        WebElement randomBranch = branchPage.getBranches().get(0);
+        WebElement randomBranch = sectionPage.getBranches().get(0);
         randomBranch.click();
         return Branch.fromForm(randomBranch);
+    }
+
+    public static void clickMarkAllAsRead() {
+        throw new UnsupportedOperationException("This is just stub method. Implementation will be created in the future");
     }
 
     public static void assertUserBrowsesBranch(Branch branch) {
@@ -60,13 +118,13 @@ public class Branches {
 
     public static void assertBranchIsVisible(String branchTitle) {
         info("Begin searching for [" + branchTitle + "] branch");
-        assertNotNull(branchPage.findBranch(branchTitle), "Branch was not found");
+        assertNotNull(sectionPage.findBranch(branchTitle), "Branch was not found");
         info("Success. Branch was found");
     }
 
     public static void assertBranchIsInvisible(String branchTitle) {
         info("Begin searching for \"" + branchTitle + "\" branch");
-        assertNull(branchPage.findBranch(branchTitle), "Branch is visible");
+        assertNull(sectionPage.findBranch(branchTitle), "Branch is visible");
         info("Success. Branch wasn't found");
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Notifications.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Notifications.java
@@ -1,43 +1,94 @@
 package org.jtalks.tests.jcommune.webdriver.action;
 
-import org.jtalks.tests.jcommune.webdriver.entity.branch.Branch;
+import org.jtalks.tests.jcommune.mail.pochta.PochtaMail;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
 import org.jtalks.tests.jcommune.webdriver.entity.user.User;
 
-import javax.jws.soap.SOAPBinding;
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
 
+/**
+ * @author pancheshenko andrey
+ */
 public class Notifications {
 
-    public static void assertNotificationOnBranchSent(Branch branch, User user){
-        throw new UnsupportedOperationException("To be implemented");
-    }
-
-    public static void assertNotificationsOnBranchNotSent(Branch branch, User user) {
-        throw new UnsupportedOperationException();
-    }
-
-    public static void assertNotificationOnTopicSent(Topic topic, User user){
-        throw new UnsupportedOperationException();
-    }
-
-    public static void assertNotificationsOnTopicNotSent(Topic topic, User user) {
-        throw new UnsupportedOperationException();
-    }
+    private static boolean topicResult;
+    private static boolean branchResult;
 
     public static void assertNotificationOnTopicSentBranchNotSent(Topic topic, User user) {
-        throw new UnsupportedOperationException();
+        if (!checkCurrentNotificationsShortCycle(user)) {
+            checkCurrentNotifications(user);
+        }
+        if (!topicResult || branchResult) {
+            throw new AssertionError("Assertion failed"); // todo info what actually failed
+        }
     }
 
     public static void assertNotificationOnTopicNotSentBranchSent(Topic topic, User user) {
-        throw new UnsupportedOperationException();
+        if (!checkCurrentNotificationsShortCycle(user)) {
+            checkCurrentNotifications(user);
+        }
+        if (topicResult || !branchResult) {
+            throw new AssertionError("Assertion failed");
+        }
     }
 
-    public static void assertNotificationsNotSent(Topic topic, User user){
-        throw new UnsupportedOperationException("To be implemented");
+    public static void assertNotificationsNotSent(Topic topic, User user) {
+        if (!checkCurrentNotificationsShortCycle(user)) {
+            checkCurrentNotifications(user);
+        }
+        if (topicResult || branchResult) {
+            throw new AssertionError("Assertion failed");
+        }
     }
 
+    private static boolean checkCurrentNotificationsShortCycle(User user) {
+        info("Short cycle notifications check start.");
+        info("Asserting whether topic notification was received.");
+        topicResult = isNotificationReceivedNoTimeout("/posts", user.getEmail());
+        info("Topic notification mail was " + (topicResult ? "received" : "not sent"));
 
+        info("Asserting whether branch notification was received...");
+        branchResult = isNotificationReceivedNoTimeout("/branches", user.getEmail());
+        info("Branch notification mail was " + (branchResult ? "received" : "not sent"));
+        return (topicResult || branchResult);
+    }
 
+    private static void checkCurrentNotifications(User user) {
+        info("Asserting whether topic notification was received...");
+        topicResult = isNotificationReceived("/posts", user.getEmail());
+        info("Topic notification mail was " + (topicResult ? "received" : "not sent"));
 
+        info("Asserting whether branch notification was received...");
+        branchResult = isNotificationReceivedNoTimeout("/branches", user.getEmail());
+        info("Branch notification mail was " + (branchResult ? "received" : "not sent"));
+    }
 
+    /**
+     * Following method checks if the mail for the current @email is received.
+     * Standard timeout (PochtaMail.MAILTRAP_NOTIFY_TIMEOUT_SECS = 20) is used
+     *
+     * @param stringToFindInBody - is the part of the link inside the message body that differs two types of notifications
+     * @param email - user's email that should receive the notification
+     *
+     */
+    private static boolean isNotificationReceived(String stringToFindInBody, String email) {
+        PochtaMail mailtrapMail = new PochtaMail();
+        return mailtrapMail.findNotificationMail(stringToFindInBody, email);
+    }
+
+    /**
+     * Following method checks if the mail for the current @email is received.
+     * No timeout is used. This method should be used when the standard maximum timeout
+     * (PochtaMail.MAILTRAP_NOTIFY_TIMEOUT_SECS = 20) or less (in positive case) is used.
+     * The logic is that we don't need to wait standard timeout twice if we check
+     * Topic notification mail and Branch notification mail right after that.
+     *
+     * @param stringToFindInBody - is the part of the link inside the message body that differs two types of notifications
+     * @param email - user's email that should receive the notification
+     *
+     */
+    private static boolean isNotificationReceivedNoTimeout(String stringToFindInBody, String email) {
+        PochtaMail mailtrapMail = new PochtaMail();
+        return mailtrapMail.findNotificationMailNoTimeout(stringToFindInBody, email);
+    }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Notifications.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Notifications.java
@@ -11,56 +11,24 @@ import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
  */
 public class Notifications {
 
-    private static boolean topicResult;
-    private static boolean branchResult;
-
-    public static void assertNotificationOnTopicSentBranchNotSent(Topic topic, User user) {
-        if (!checkCurrentNotificationsShortCycle(user)) {
-            checkCurrentNotifications(user);
-        }
-        if (!topicResult || branchResult) {
-            throw new AssertionError("Assertion failed"); // todo info what actually failed
-        }
+    public static void assertTopicNotificationSent(User user) {
+        if (!isNotificationReceived("/posts", user.getEmail()))
+            throw new AssertionError("Topic notification was not received. Assertion failed");
     }
 
-    public static void assertNotificationOnTopicNotSentBranchSent(Topic topic, User user) {
-        if (!checkCurrentNotificationsShortCycle(user)) {
-            checkCurrentNotifications(user);
-        }
-        if (topicResult || !branchResult) {
-            throw new AssertionError("Assertion failed");
-        }
+    public static void assertTopicNotificationNotSent(User user) {
+        if (isNotificationReceived("/posts", user.getEmail()))
+            throw new AssertionError("Topic notification received. Assertion failed");
     }
 
-    public static void assertNotificationsNotSent(Topic topic, User user) {
-        if (!checkCurrentNotificationsShortCycle(user)) {
-            checkCurrentNotifications(user);
-        }
-        if (topicResult || branchResult) {
-            throw new AssertionError("Assertion failed");
-        }
+    public static void assertBranchNotificationSent(User user) {
+        if (!isNotificationReceived("/branches", user.getEmail()))
+            throw new AssertionError("Branch notification was not received. Assertion failed");
     }
 
-    private static boolean checkCurrentNotificationsShortCycle(User user) {
-        info("Short cycle notifications check start.");
-        info("Asserting whether topic notification was received.");
-        topicResult = isNotificationReceivedNoTimeout("/posts", user.getEmail());
-        info("Topic notification mail was " + (topicResult ? "received" : "not sent"));
-
-        info("Asserting whether branch notification was received...");
-        branchResult = isNotificationReceivedNoTimeout("/branches", user.getEmail());
-        info("Branch notification mail was " + (branchResult ? "received" : "not sent"));
-        return (topicResult || branchResult);
-    }
-
-    private static void checkCurrentNotifications(User user) {
-        info("Asserting whether topic notification was received...");
-        topicResult = isNotificationReceived("/posts", user.getEmail());
-        info("Topic notification mail was " + (topicResult ? "received" : "not sent"));
-
-        info("Asserting whether branch notification was received...");
-        branchResult = isNotificationReceivedNoTimeout("/branches", user.getEmail());
-        info("Branch notification mail was " + (branchResult ? "received" : "not sent"));
+    public static void assertBranchNotificationNotSent(User user) {
+        if (isNotificationReceived("/branches", user.getEmail()))
+            throw new AssertionError("Branch notification received. Assertion failed");
     }
 
     /**

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Topics.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Topics.java
@@ -64,7 +64,7 @@ public class Topics {
     @Step
     public static Topic createTopic(Topic topic) throws PermissionsDeniedException, CouldNotOpenPageException, ValidationException {
         if (!JCommuneSeleniumConfig.driver.getCurrentUrl().equals(JCommuneSeleniumConfig.getAppUrl())) {
-            gotoMainPage();
+            mainPage.clickForumsTitle();
         }
         if (topic.getBranch() == null) {
             List<WebElement> branches = sectionPage.getBranches();
@@ -242,29 +242,20 @@ public class Topics {
         return found;
     }
 
-    private static void gotoMainPage() {
-        mainPage.clickForumsTitle();
-    }
-
-    public static void goToBranchPage() throws ValidationException {
+    public static void w3cGoToBranchPage() throws ValidationException {
         Users.signUpAndSignIn();
-        Topic topic = new Topic("subject123", "New final test answer");
-        if (topic.getBranch() == null) {
-            Branch branch = new Branch(sectionPage.getBranches().get(0).getText());
-            topic.withBranch(branch);
-        }
-        Branches.openBranch(topic.getBranch());
+        Branch branch = new Branch(sectionPage.getBranches().get(0).getText());
+        Branches.openBranch(branch);
     }
 
-    public static void goToTopicCreatePage() throws ValidationException {
-        goToBranchPage();
-        branchPage.getNewOrdinaryTopicButton().click();
+    public static void w3cGoToTopicCreatePage() throws ValidationException {
+        w3cGoToBranchPage();
+        branchPage.clickCreateTopic();
     }
 
-    public static void goToReviewCreatePage() throws ValidationException {
-        goToBranchPage();
-        branchPage.getNewTopicToggle().click();
-        branchPage.getNewCodeReviewButton().click();
+    public static void w3cGoToReviewCreatePage() throws ValidationException {
+        w3cGoToBranchPage();
+        branchPage.clickCreateCodeReview();
     }
 
     public static boolean isCreated(Topic topic) {

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Users.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Users.java
@@ -74,6 +74,12 @@ public class Users {
     }
 
     @Step
+    public static void logOutAndSignIn(User user) throws ValidationException {
+        logout();
+        signIn(user);
+    }
+
+    @Step
     public static void logout() {
         mainPage.clickLogout();
     }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/CodeReview.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/CodeReview.java
@@ -3,6 +3,8 @@ package org.jtalks.tests.jcommune.webdriver.entity.topic;
 import com.google.common.base.Splitter;
 import org.jtalks.tests.jcommune.webdriver.entity.branch.Branch;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
@@ -14,7 +16,7 @@ public class CodeReview extends Topic {
 
     private String content = randomAlphanumeric(50);
     private int numberOfLines = 1;
-    private List<CodeReviewComment> comments;
+    private List<CodeReviewComment> comments = new ArrayList<CodeReviewComment>();
 
     public CodeReview() {}
 
@@ -35,6 +37,12 @@ public class CodeReview extends Topic {
         return this;
     }
 
+    @Override
+    public CodeReview withBranch(String branchName) {
+        this.branch = new Branch(branchName);
+        return this;
+    }
+
     public CodeReview withNumberOfLines(int numberOfLines) {
         this.numberOfLines = numberOfLines;
         if (!this.content.equals("")) {
@@ -50,10 +58,6 @@ public class CodeReview extends Topic {
     public CodeReview withTitle(String title){
         super.withTitle(title);
         return this;
-    }
-
-    public CodeReview withBranch(String branchName) {
-        throw new UnsupportedOperationException("To be implemented");
     }
 
     public String getContent() {

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Topic.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Topic.java
@@ -15,7 +15,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
  * Jcommune topic representation.
  */
 public class Topic {
-    private Branch branch;
+    protected Branch branch;
     private DateTime creationDate;
     private DateTime modificationDate;
     private User topicStarter;
@@ -48,16 +48,8 @@ public class Topic {
         return this;
     }
 
-    public DateTime getModificationDate() {
-        return modificationDate;
-    }
-
     public void setModificationDate(DateTime modificationDate) {
         this.modificationDate = modificationDate;
-    }
-
-    public User getTopicStarter() {
-        return topicStarter;
     }
 
     public Topic withTopicStarter(User topicStarter) {
@@ -65,56 +57,32 @@ public class Topic {
         return this;
     }
 
-    public String getTitle() {
-        return title;
-    }
-
-    public boolean isSticked() {
-        return sticked;
-    }
-
     public void setSticked(boolean sticked) {
         this.sticked = sticked;
-    }
-
-    public boolean isAnnouncement() {
-        return announcement;
     }
 
     public void setAnnouncement(boolean announcement) {
         this.announcement = announcement;
     }
 
-    public Boolean getClosed() {
-        return closed;
-    }
-
     public void setClosed(Boolean closed) {
         this.closed = closed;
-    }
-
-    public int getViews() {
-        return views;
     }
 
     public void setViews(int views) {
         this.views = views;
     }
 
-    public Poll getPoll() {
-        return poll;
-    }
-
     public void setPoll(Poll poll) {
         this.poll = poll;
     }
 
-    public List<Post> getPosts() {
-        return posts;
-    }
-
     public void setPosts(List<Post> posts) {
         this.posts = posts;
+    }
+
+    public void addPost(Post post) {
+        posts.add(post);
     }
 
     public Branch getBranch() {
@@ -131,14 +99,6 @@ public class Topic {
         return this;
     }
 
-    public Post getFirstPost() {
-        return getPosts().get(0);
-    }
-
-    public Post getLastPost() {
-        return getPosts().get(getPosts().size() - 1);
-    }
-
     public boolean hasNewMessages() {
         return hasNewMessages;
     }
@@ -151,4 +111,52 @@ public class Topic {
     public String toString() {
         return String.format("Topic: title=[%s]", this.title);
     }
+
+    //Getters
+
+    public int getViews() {
+        return views;
+    }
+
+    public Poll getPoll() {
+        return poll;
+    }
+
+    public List<Post> getPosts() {
+        return posts;
+    }
+
+    public DateTime getModificationDate() {
+        return modificationDate;
+    }
+
+    public User getTopicStarter() {
+        return topicStarter;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public boolean isSticked() {
+        return sticked;
+    }
+
+    public boolean isAnnouncement() {
+        return announcement;
+    }
+
+    public Boolean getClosed() {
+        return closed;
+    }
+
+    public Post getFirstPost() {
+        return getPosts().get(0);
+    }
+
+    public Post getLastPost() {
+        return getPosts().get(getPosts().size() - 1);
+    }
+
+
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/user/User.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/user/User.java
@@ -37,9 +37,9 @@ public class User {
     private String newPassword = "";
     private String confirmPassword = "";
     private String currentPassword = "";
-    private boolean autoSubscribe = false;
+    private boolean autoSubscribe = true;
     private boolean notifyIfSomeoneMentionsYou = false;
-    private boolean notifyIfPrivateMessageIsReceived = false;
+    private boolean notifyIfPrivateMessageIsReceived = true;
 
     public User() {
     }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/BranchPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/BranchPage.java
@@ -1,30 +1,175 @@
 package org.jtalks.tests.jcommune.webdriver.page;
 
+import org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig;
+import org.jtalks.tests.jcommune.webdriver.exceptions.CouldNotOpenPageException;
+import org.jtalks.tests.jcommune.webdriver.exceptions.PermissionsDeniedException;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import ru.yandex.qatools.allure.annotations.Step;
 
 import java.util.List;
 
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+
+/**
+ * @author pancheshenko andrey
+ */
 public class BranchPage {
-    @FindBy(className = "branch-title")
-    private List<WebElement> branchList;
+
+    @FindBy(xpath = "//a[@id='subscription' and contains(@href, '/branches/')]")
+    private WebElement subscribeButton;
+
+    @FindBy(xpath = "//a[@class='invisible-link' and contains(@href, '/branches/')]")
+    private WebElement branchName;
+
+    @FindBy(xpath = "//div[@class='pagination pull-right forum-pagination']/ul/li/a")
+    private List<WebElement> topicsButtons;
+
+    @FindBy(xpath = "//div[@class='pagination pull-right forum-pagination']/ul/li[@class='active']/a")
+    private List<WebElement> activeTopicsButton;
+
+    @FindBy(className = "topic-types-dropdown")
+    private WebElement newTopicTypeToggle;
+
+    @FindBy(className = "new-topic-btn")
+    private WebElement newOrdinaryTopicButton;
+
+    @FindBy(className = "new-code-review-btn")
+    private WebElement newCodeReviewButton;
+
+    @FindBy(xpath = "//table[@id='topics-table']/tbody/tr/td[@class='posts-td-small posts-td-small_2']/h2/a[contains(@href, '" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/topics/')]")
+    private List<WebElement> topicsList;
+
+    private final WebDriver driver;
 
     public BranchPage(WebDriver driver) {
         PageFactory.initElements(driver, this);
+        this.driver = driver;
     }
 
-    public WebElement findBranch(String branchTitle) {
-        for (WebElement branch : getBranches()) {
-            if (branch.getText().equals(branchTitle)) {
-                return branch;
+    @Step
+    public void clickCreateTopic() throws PermissionsDeniedException {
+        info("Clicking New Topic button");
+        try {
+            getNewOrdinaryTopicButton().click();
+        } catch (NoSuchElementException e) {
+            info("No such button found!");
+            throw new PermissionsDeniedException("Couldn't find New Topic button. Here is the page source: \n"
+                    + driver.getPageSource());
+        }
+    }
+
+    @Step
+    public void clickCreateCodeReview() throws PermissionsDeniedException {
+        info("Clicking New Code Review Button");
+        try {
+            if (getNewTopicToggle() != null) {
+                getNewTopicToggle().click();
+            }
+            getNewCodeReviewButton().click();
+        } catch (NoSuchElementException e) {
+            info("No such button found!");
+            throw new PermissionsDeniedException("Couldn't find New Code Review button. Here is the page source: \n"
+                    + driver.getPageSource());
+        }
+    }
+
+    public boolean isUserAlreadySubscribed() {
+        return subscribeButton.getAttribute("href").contains("/unsubscribe");
+    }
+
+    public boolean isUserInsideCorrectBranch(String branchTitle) {
+        info("Check whether user is in required branch already or inside some topic from this branch");
+        if (JCommuneSeleniumConfig.driver.getCurrentUrl().contains("/branches/")) {
+            return branchName.getText().trim().equals(branchTitle);
+        } else if (JCommuneSeleniumConfig.driver.getCurrentUrl().contains("/topics/")) {
+            return postPage.getBranchName().getText().trim().equals(branchTitle);
+        }
+        return false;
+    }
+
+    public boolean openNextPage(int pagesToCheck) {
+        info("Trying to open next page on the active branch...");
+        int max = 0;
+        if (getActiveTopicsButton().size() < 1) {
+            return false;
+        }
+        WebElement activeBtn = getActiveTopicsButton().get(0);
+        int active = Integer.parseInt(activeBtn.getText().trim());
+        for (WebElement el : getTopicsButtons()) {
+            try {
+                Integer currentPageNumberInCycle = Integer.parseInt(el.getText().trim());
+                if (currentPageNumberInCycle > max)
+                    max = currentPageNumberInCycle;
+            } catch (NumberFormatException e) {}
+        }
+        if ((active < pagesToCheck) && (active < max)) {
+            for (WebElement elem : getTopicsButtons()) {
+                try {
+                    Integer currentPageNumberInCycle = Integer.parseInt(elem.getText().trim());
+                    if (currentPageNumberInCycle == (active + 1)) {
+                        info("Opening " + currentPageNumberInCycle + " page");
+                        elem.click();
+                        return true;
+                    }
+                } catch (NumberFormatException e) {}
             }
         }
-        return null;
+        info("End of the 'Open next page' loop reached");
+        return false;
     }
 
-    public List<WebElement> getBranches() {
-        return branchList;
+    public boolean findAndOpenTopic(String topicTitle) throws CouldNotOpenPageException {
+        boolean found = false;
+        for (WebElement topics : getTopicsList()) {
+            if (topics.getText().trim().equals(topicTitle.trim())) {
+                topics.click();
+                info("Waiting for the topic to be opened");
+                (new WebDriverWait(driver, 20)).until(ExpectedConditions.visibilityOf(postPage.getFirstPost()));
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    // Getters
+
+    public WebElement getSubscribeButton() {
+        return subscribeButton;
+    }
+
+    public WebElement getBranchName() {
+        return branchName;
+    }
+
+    public List<WebElement> getActiveTopicsButton() {
+        return activeTopicsButton;
+    }
+
+    public List<WebElement> getTopicsButtons() {
+        return topicsButtons;
+    }
+
+    public WebElement getNewTopicToggle() {
+        return newTopicTypeToggle;
+    }
+
+    public WebElement getNewOrdinaryTopicButton() {
+        return newOrdinaryTopicButton;
+    }
+
+    public WebElement getNewCodeReviewButton() {
+        return newCodeReviewButton;
+    }
+
+    public List<WebElement> getTopicsList() {
+        return topicsList;
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/MoveTopicEditor.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/MoveTopicEditor.java
@@ -1,0 +1,125 @@
+package org.jtalks.tests.jcommune.webdriver.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+
+/**
+ * @author pancheshenko andrey
+ */
+public class MoveTopicEditor {
+    public static final String moveTopicEditorFormSel = "move-topic-editor";
+
+    public static final String selectWithSectionNamesSel = "section_name";
+
+    public static final String selectWithBranchNamesSel = "branch_name";
+
+    public static final String firstBranchInMoveTopicEditorSel = "//select[@id='branch_name']/option[@value='1']";
+
+    public static final String confirmMoveButtonSel = "move-button-save";
+
+    @FindBy(id = moveTopicEditorFormSel)
+    private WebElement moveTopicEditorForm;
+
+    @FindBy(id = selectWithSectionNamesSel)
+    private WebElement selectWithSectionNames;
+
+    @FindBy(id = selectWithBranchNamesSel)
+    private WebElement selectWithBranchNames;
+
+    @FindBy(id = confirmMoveButtonSel)
+    private WebElement confirmMoveButton;
+
+    private WebDriver driver;
+
+    public MoveTopicEditor(WebDriver driver) {
+        PageFactory.initElements(driver, this);
+        this.driver = driver;
+    }
+
+    /**
+     * This method will choose 'All sections' in sections list, and then choose
+     * the @branchNameDest branch title in the branch list.
+     *
+     * @param branchNameDest - title of the required branch to choose in the 'All sections' list
+     * @return
+     */
+    public void chooseBranch(String branchNameDest) {
+        info("Selecting the [" + branchNameDest + "] branch in the [All sections] list");
+        Select sectionList = new Select(getSelectWithSectionNames());
+        for (WebElement sectionListCurrentOption : sectionList.getOptions()) {
+            if (sectionListCurrentOption.getText().equals("All sections")) {
+                sectionListCurrentOption.click();
+                info("Section [" + sectionListCurrentOption.getText() + "] was selected");
+                break;
+            }
+        }
+
+        (new WebDriverWait(driver, 10)).until(ExpectedConditions.presenceOfElementLocated(By.xpath(firstBranchInMoveTopicEditorSel)));
+
+        Select branchList = new Select(getSelectWithBranchNames());
+        for (WebElement branchNameFromList : branchList.getOptions()) {
+            if (branchNameFromList.getText().equals(branchNameDest)) {
+                branchNameFromList.click();
+                info("Branch [" + branchNameFromList.getText() + "] was selected");
+                return;
+            }
+        }
+        throw new NoSuchElementException("Branch [" + branchNameDest + "] was not found in the 'All branches' list.");
+    }
+
+    /**
+     * This method will choose 'All sections' in sections list, and then choose
+     * the @branchIndex branch index in the branch list.
+     *
+     * @param branchIndex - index of the required branch to choose in the 'All sections' list
+     * @return - returns the title of the chosen branch if the index was inside the bounds
+     */
+    public String chooseBranchIndex(Integer branchIndex) {
+        info("Selecting the [" + (branchIndex + 1) + "] branch number in the 'All branches' list");
+        Select sectionList = new Select(getSelectWithSectionNames());
+        sectionList.getOptions().get(0).click(); // select 'All sections'
+
+        (new WebDriverWait(driver, 10)).until(ExpectedConditions.presenceOfElementLocated(By.xpath(firstBranchInMoveTopicEditorSel)));
+
+        Select branchList = new Select(getSelectWithBranchNames());
+        if (branchIndex < branchList.getOptions().size()) {
+            WebElement branchNameFromList = branchList.getOptions().get(branchIndex);
+            branchNameFromList.click();
+            info("Branch [" + branchNameFromList.getText() + "] was selected");
+            return branchNameFromList.getText();
+        }
+        throw new IndexOutOfBoundsException("Desired branch index is out of bounds for the 'All branches' list.");
+    }
+
+    public void clickConfirmMoveButton() {
+        info("Clicking move confirmation button in move topic editor");
+        getConfirmMoveButton().click();
+    }
+
+    // Getters
+
+    public WebElement getMoveTopicEditorForm() {
+        return moveTopicEditorForm;
+    }
+
+    public WebElement getSelectWithSectionNames() {
+        return selectWithSectionNames;
+    }
+
+    public WebElement getSelectWithBranchNames() {
+        return selectWithBranchNames;
+    }
+
+    public WebElement getConfirmMoveButton() {
+        return confirmMoveButton;
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/Pages.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/Pages.java
@@ -15,6 +15,7 @@ public class Pages {
     public static ProfilePage profilePage;
     public static ExternalLinksDialog externalLinksDialog;
     public static ForumSettingsDialog forumSettingsDialog;
+    public static MoveTopicEditor moveTopicEditor;
 
 
     public static void createAllPages(WebDriver driver) {
@@ -29,5 +30,6 @@ public class Pages {
         profilePage = new ProfilePage(driver);
         externalLinksDialog = new ExternalLinksDialog(driver);
         forumSettingsDialog = new ForumSettingsDialog(driver);
+        moveTopicEditor = new MoveTopicEditor(driver);
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
@@ -1,21 +1,38 @@
 package org.jtalks.tests.jcommune.webdriver.page;
 
+import com.google.common.base.Splitter;
+import org.apache.commons.lang3.StringUtils;
+import org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.CodeReviewComment;
+import org.jtalks.tests.jcommune.webdriver.exceptions.PermissionsDeniedException;
+import org.jtalks.tests.jcommune.webdriver.exceptions.TimeoutException;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.util.List;
 
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.moveTopicEditor;
 
 /**
  * @author masyan
+ * @author pancheshenko andrey
  */
 public class PostPage {
 
-    public static final String messageFieldSel = "tbMsg";
+    public static final String topicTitleSel = "//a[@class='invisible-link' and contains(@href, '/topics/')]";
+
+    public static final String messageFieldSel = "postBody";
 
     public static final String postButtonSel = "post";
+
+    public static final String branchNameSel = "//ul[@class='breadcrumb']/li[last()]/h2/a";
 
     public static final String lastPostMessageSel = "//div[@class='post'][last()]/table/tbody/tr/td[@class='post-content-td']/div";
 
@@ -23,25 +40,37 @@ public class PostPage {
 
     public static final String backButtonSel = "//a[@class='back-btn']";
 
+    public static final String subscribeButtonSel = "//a[@id='subscription' and contains(@href, '/topics/')]";
+
     public static final String deleteButtonNearLastPostSel = "//div[@class='post'][last()]//a[@class='btn btn-mini btn-danger delete']";
 
     public static final String linkButtonNearLastPostSel = "//div[@class='post'][last()]//a[@class='btn btn-mini postLink']";
 
-    public static final String deleteTopicButtonSel = "//div[@class='post']//a[@class='btn btn-mini btn-danger delete']";
+    public static final String deleteTopicButtonSel = "//a[@class='btn btn-mini btn-danger delete' and contains(@href, 'topics')]";
 
-    public static final String deleteConfirmOkButtonSel = "jqi_state0_buttonOk";
+    public static final String deletePostButtonSel = "//a[@class='btn btn-mini btn-danger delete' and contains(@href, 'posts')]";
+
+    public static final String deleteConfirmOkButtonSel = "remove-entity-ok";
+
+    public static final String deleteCRCommentConfirmOkButtonSel = "remove-review-ok";
 
     public static final String deleteConfirmCancelButtonSel = "jqi_state0_buttonCancel";
 
     public static final String postErrorMessageSel = "bodyText.errors";
 
-    public static final String postsListSel = "//div[@class='post']";
+    public static final String firstPostSel = "//div[@class='post script-first-post']";
 
-    public static final String postsMessagesSel = "//div[@class='post']/table/tbody/tr/td[@class='post-content-td']/div";
+    public static final String postsListSel = "//div[@class='container']/div/div[contains(@class,'post')]";
+
+    public static final String postMessageSel = "//td[@class='post-content-td']/div";
+
+    public static final String editButtonCommonSel = "//a[contains(@class,'edit_button')]";
 
     public static final String editPostButtonSel = "//a[contains(@class,'edit_button') and contains(@href, 'posts')]";
 
     public static final String editTopicButtonSel = "//a[contains(@class,'edit_button') and contains(@href, 'topics')]";
+
+    public static final String moveTopicButtonSel = "//div[contains(@class, 'upper-pagination')]/div/a[@class='move_topic btn space-left-medium-nf']";
 
     public static final String permanentUrlToPostSel = "//div[@class='jqimessage']";
 
@@ -59,6 +88,25 @@ public class PostPage {
 
     public static final String authorsOfPostsListSel = "//div[@class='post']/table/tbody/tr/td[@class='userinfo']/div/a[@class='post-userinfo-username']";
 
+    public static final String codeReviewLineSel = "//ol[@class='linenums']/li";
+
+    public static final String codeReviewCommentsListSel = "//div[@class='review-container']";
+
+    public static final String codeReviewCommentBodySel = "//div[@class='review-body']";
+
+    public static final String codeReviewCommentEditButtonSel = "//a[@name='edit-review']";
+
+    public static final String codeReviewCommentDeleteButtonSel = "//a[@name='delete-review']";
+
+    public static final String codeReviewCommentTextFieldSel = "//textarea[@class='review-container-content']";
+
+    public static final String codeReviewCommentConfirmButtonSel = "//input[@class='btn btn-primary review-container-controls-ok']";
+
+    public static final String codeReviewCommentBodyErrorMessageSel = "//div[@id='add-comment-form']/div[@class='control-group error']/span[@class='help-inline']";
+
+    @FindBy(xpath = topicTitleSel)
+    private WebElement topicTitle;
+
     @FindBy(xpath = lastPostAuthorSel)
     private WebElement lastPostAuthor;
 
@@ -68,11 +116,17 @@ public class PostPage {
     @FindBy(id = postButtonSel)
     private WebElement postButton;
 
+    @FindBy(xpath = branchNameSel)
+    private WebElement branchName;
+
     @FindBy(xpath = lastPostMessageSel)
     private WebElement lastPostMessage;
 
     @FindBy(xpath = backButtonSel)
     private WebElement backButton;
+
+    @FindBy(xpath = subscribeButtonSel)
+    private WebElement subscribeButton;
 
     @FindBy(xpath = deleteButtonNearLastPostSel)
     private WebElement deleteButtonNearLastPost;
@@ -86,23 +140,35 @@ public class PostPage {
     @FindBy(id = deleteConfirmCancelButtonSel)
     private WebElement deleteConfirmCancelButton;
 
+    @FindBy(id = deleteCRCommentConfirmOkButtonSel)
+    private WebElement deleteCRCommentConfirmOkButton;
+
     @FindBy(id = postErrorMessageSel)
     private WebElement postErrorMessage;
+
+    @FindBy(xpath = firstPostSel)
+    private WebElement firstPost;
 
     @FindBy(xpath = postsListSel)
     private List<WebElement> postsList;
 
-    @FindBy(xpath = postsMessagesSel)
+    @FindBy(xpath = postMessageSel)
     private List<WebElement> postsMessages;
 
     @FindBy(xpath = deleteTopicButtonSel)
     private WebElement deleteTopicButton;
+
+    @FindBy(xpath = deletePostButtonSel)
+    private WebElement deletePostButton;
 
     @FindBy(xpath = editPostButtonSel)
     private WebElement editPostButton;
 
     @FindBy(xpath = editTopicButtonSel)
     private WebElement editTopicButton;
+
+    @FindBy(xpath = moveTopicButtonSel)
+    private WebElement moveTopicButton;
 
     @FindBy(xpath = permanentUrlToPostSel)
     private WebElement permanentUrlToPost;
@@ -128,14 +194,200 @@ public class PostPage {
     @FindBy(xpath = authorsOfPostsListSel)
     private List<WebElement> authorsOfPostsList;
 
+    @FindBy(xpath = codeReviewLineSel)
+    private List<WebElement> codeReviewLines;
+
+    @FindBy(xpath = codeReviewCommentsListSel)
+    private List<WebElement> codeReviewCommentsList;
+
+    @FindBy(xpath = codeReviewCommentBodySel)
+    private WebElement codeReviewCommentBody;
+
+    @FindBy(xpath = codeReviewCommentEditButtonSel)
+    private WebElement codeReviewCommentEditButton;
+
+    @FindBy(xpath = codeReviewCommentDeleteButtonSel)
+    private WebElement codeReviewCommentDeleteButton;
+
+    @FindBy(xpath = codeReviewCommentTextFieldSel)
+    private WebElement codeReviewCommentTextField;
+
+    @FindBy(xpath = codeReviewCommentConfirmButtonSel)
+    private WebElement codeReviewCommentConfirmButton;
+
+    @FindBy(xpath = codeReviewCommentBodyErrorMessageSel)
+    private WebElement codeReviewCommentBodyErrorMessage;
+
+    private WebDriver driver;
 
     public PostPage(WebDriver driver) {
         PageFactory.initElements(driver, this);
+        this.driver = driver;
     }
 
+    public void clickAnswerToTopicButton() throws PermissionsDeniedException {
+        info("Clicking a button to add post in the topic");
+        try {
+            getPostButton().click();
+            info("The button was clicked");
+        } catch (NoSuchElementException e) {
+            info("Couldn't click the button, looks like the permissions are granted");
+            throw new PermissionsDeniedException("User does not have permissions to leave posts in the branch");
+        }
+    }
+
+    public void clickLineInCodeReviewForComment(int lineNumber) throws PermissionsDeniedException {
+        info("Clicking a line #" + lineNumber + " to leave comment");
+        if(getCRLines().size()<lineNumber) {
+            info("Passed linenumber is greater than the number of lines in the code review topic. Clicking on the last line.");
+            getCRLines().get(getCRLines().size()-1).click();
+        } else {
+            getCRLines().get(lineNumber - 1).click();
+        }
+        try {
+            (new WebDriverWait(driver, 5)).until(ExpectedConditions.visibilityOf(getCRCommentTextField()));
+        } catch (TimeoutException e) {
+            info("Clicking the line does nothing, looks like the permissions are not granted");
+            throw new PermissionsDeniedException("User does not have permissions to leave comments in branch");
+        }
+    }
+
+    public void fillCodeReviewCommentBody(CodeReviewComment codeReviewComment) {
+        info("Filling code review comment body: [" + StringUtils.left(codeReviewComment.getPostContent(), 100) + "...]");
+        getCRCommentTextField().sendKeys(codeReviewComment.getPostContent());
+    }
+
+    public void clickAddCommentToCodeReviewButton() throws PermissionsDeniedException {
+        info("Clicking a button to add comment to code review");
+        try {
+            getCRCommentConfirmButton().click();
+            info("The button was clicked");
+        } catch (NoSuchElementException e) {
+            info("Couldn't click the button, looks like the permissions are not granted");
+            throw new PermissionsDeniedException("User does not have permissions to leave comments in the branch");
+        }
+    }
+
+    public void clickEditInPostContainingString(String postContent) {
+        info("Trying to find post with content: " + postContent);
+        for (WebElement currentPost : getPostsList()) {
+            if (currentPost.findElement(By.xpath("." + postMessageSel)).getText().contains(postContent)) {
+                info("Post was found. Clicking edit button...");
+                try {
+                    currentPost.findElement(By.xpath("." + editButtonCommonSel)).click();
+                } catch (NoSuchElementException e) {
+                    throw new NoSuchElementException("Edit button wasn't found in the post. Lack of permissions?");
+                }
+                break;
+            }
+        }
+    }
+
+    public void clickEditInCodeReviewCommentContainingString(String commentContent) {
+        info("Trying to find comment with content: " + commentContent);
+        for (WebElement currentComment : getCRCommentsList()) {
+            if(currentComment.findElement(By.xpath("." + codeReviewCommentBodySel)).getText().contains(commentContent)) {
+                info("Comment was found. Clicking edit button...");
+                try {
+                    currentComment.findElement(By.xpath("." + codeReviewCommentEditButtonSel)).click();
+                } catch (NoSuchElementException e) {
+                    throw new NoSuchElementException("Edit button wasn't found in the comment. Lack of permissions?");
+                }
+            }
+        }
+    }
+
+    public void clickDeleteInCodeReviewCommentContainingString(String commentContent) {
+        info("Trying to find comment with content: " + commentContent);
+        for (WebElement currentComment : getCRCommentsList()) {
+            if(currentComment.findElement(By.xpath("." + codeReviewCommentBodySel)).getText().contains(commentContent)) {
+                info("Comment was found. Clicking delete button...");
+                try {
+                    currentComment.findElement(By.xpath("." + codeReviewCommentDeleteButtonSel)).click();
+                } catch (NoSuchElementException e) {
+                    throw new NoSuchElementException("Delete button wasn't found in the comment. Lack of permissions?");
+                }
+            }
+        }
+    }
+
+    public void editCodeReviewCommentBody(String newMessage) {
+        info("Editing comment body");
+        getCRCommentTextField().clear();
+        for (String token : Splitter.fixedLength(100).split(newMessage)) {
+            getCRCommentTextField().sendKeys(token);
+        }
+    }
+
+    public void clickOkButtonInEditComment() {
+        info("Clicking a button to confirm changes in the code review comment");
+        try {
+            getCRCommentConfirmButton().click();
+            info("The confirmation button [Edit] was clicked");
+        } catch (NoSuchElementException e) {
+            throw new NoSuchElementException("[Edit] confirmation button wasn't found.");
+        }
+    }
+
+    public void closeDeleteConfirmDialogOk() {
+        try {
+            info("Waiting for post/topic delete confirmation dialog...");
+            (new WebDriverWait(driver, 20)).until(ExpectedConditions.visibilityOf(getDeleteConfirmOkButton()));
+        } catch (TimeoutException e) {
+            throw new NoSuchElementException("Tried to wait delete confirmation dialog without any reaction");
+        }
+        info("The dialog showed up!");
+        getDeleteConfirmOkButton().click();
+    }
+
+    public void closeDeleteCRCommentConfirmDialogOk() {
+        try {
+            info("Waiting for code review comment delete confirmation dialog...");
+            (new WebDriverWait(driver, 20)).until(ExpectedConditions.visibilityOf(getDeleteCRCommentConfirmOkButton()));
+        } catch (TimeoutException e) {
+            throw new NoSuchElementException("Tried to wait delete confirmation dialog without any reaction");
+        }
+        info("The dialog showed up!");
+        getDeleteCRCommentConfirmOkButton().click();
+    }
+
+    public void openMoveTopicEditorDialog() {
+        try {
+            getMoveTopicButton().click();
+        } catch (NoSuchElementException e) {
+            info("Move button was not found");
+            throw new PermissionsDeniedException("Move button was not found. Lack of permissions?");
+        }
+        try {
+            info("Waiting for move topic editor dialog...");
+            (new WebDriverWait(driver, 20)).until(ExpectedConditions.visibilityOf(moveTopicEditor.getMoveTopicEditorForm()));
+        } catch (TimeoutException e) {
+            throw new NoSuchElementException("Tried to wait move topic editor dialog without any reaction");
+        }
+        info("The dialog showed up!");
+    }
+
+    public void returnToBranchPage() {
+        getBranchName().click();
+    }
+
+    public boolean isUserAlreadySubscribed() {
+        return getSubscribeButton().getAttribute("href").contains("/unsubscribe");
+    }
+
+    public boolean isUserInsideCorrectTopic(String title) {
+        info("Check whether user is in required topic already");
+        if (JCommuneSeleniumConfig.driver.getCurrentUrl().contains("/topics/")) {
+            return getTopicTitle().getText().trim().equals(title);
+        }
+        return false;
+    }
 
     //Getters
 
+    public WebElement getTopicTitle() {
+        return topicTitle;
+    }
 
     public WebElement getLastPostAuthor() {
         return lastPostAuthor;
@@ -149,12 +401,20 @@ public class PostPage {
         return postButton;
     }
 
+    public WebElement getBranchName() {
+        return branchName;
+    }
+
     public WebElement getLastPostMessage() {
         return lastPostMessage;
     }
 
     public WebElement getBackButton() {
         return backButton;
+    }
+
+    public WebElement getSubscribeButton() {
+        return subscribeButton;
     }
 
     public WebElement getDeleteButtonNearLastPost() {
@@ -173,8 +433,16 @@ public class PostPage {
         return deleteConfirmCancelButton;
     }
 
+    public WebElement getDeleteCRCommentConfirmOkButton() {
+        return deleteCRCommentConfirmOkButton;
+    }
+
     public WebElement getPostErrorMessage() {
         return postErrorMessage;
+    }
+
+    public WebElement getFirstPost() {
+        return firstPost;
     }
 
     public List<WebElement> getPostsList() {
@@ -189,12 +457,20 @@ public class PostPage {
         return deleteTopicButton;
     }
 
+    public WebElement getDeletePostButton() {
+        return deletePostButton;
+    }
+
     public WebElement getEditPostButton() {
         return editPostButton;
     }
 
     public WebElement getEditTopicButton() {
         return editTopicButton;
+    }
+
+    public WebElement getMoveTopicButton() {
+        return moveTopicButton;
     }
 
     public WebElement getPermanentUrlToPost() {
@@ -237,5 +513,33 @@ public class PostPage {
 
     public List<WebElement> getAuthorsOfPostsList() {
         return authorsOfPostsList;
+    }
+
+    public List<WebElement> getCRLines() {
+        return codeReviewLines;
+    }
+
+    public List<WebElement> getCRCommentsList() {
+        return codeReviewCommentsList;
+    }
+
+    public WebElement getCRCommentBody() {
+        return codeReviewCommentBody;
+    }
+
+    public WebElement getCRCommentEditButton() {
+        return codeReviewCommentEditButton;
+    }
+
+    public WebElement getCRCommentTextField() {
+        return codeReviewCommentTextField;
+    }
+
+    public WebElement getCRCommentConfirmButton() {
+        return codeReviewCommentConfirmButton;
+    }
+
+    public WebElement getCRCommentBodyErrorMessage() {
+        return codeReviewCommentBodyErrorMessage;
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/SectionPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/SectionPage.java
@@ -15,11 +15,12 @@ import java.util.List;
 public class SectionPage {
 
     public static final String sectionListSel = "//a[contains(@href, '" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/sections/')]";
-
     public static final String breadCrumbsSectionLinkSel = "//ul[@class='breadcrumb']//a[contains(@href,'" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/sections/')]";
 
     @FindBy(xpath = sectionListSel)
     private List<WebElement> sectionList;
+    @FindBy(className = "branch-title")
+    private List<WebElement> branchList;
 
     @FindBy(xpath = breadCrumbsSectionLinkSel)
     private WebElement breadCrumbsSectionLink;
@@ -29,9 +30,22 @@ public class SectionPage {
         PageFactory.initElements(driver, this);
     }
 
+    public WebElement findBranch(String branchTitle) {
+        for (WebElement branch : getBranches()) {
+            if (branch.getText().equals(branchTitle)) {
+                return branch;
+            }
+        }
+        return null;
+    }
+
     //Getters
     public List<WebElement> getSectionList() {
         return sectionList;
+    }
+
+    public List<WebElement> getBranches() {
+        return branchList;
     }
 
     public WebElement getBreadCrumbsSectionLink() {

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/TopicPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/TopicPage.java
@@ -1,19 +1,13 @@
 package org.jtalks.tests.jcommune.webdriver.page;
 
-
 import com.google.common.base.Splitter;
 import org.apache.commons.lang3.StringUtils;
 import org.jtalks.tests.jcommune.utils.DriverMethodHelp;
 import org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig;
-import org.jtalks.tests.jcommune.webdriver.action.Branches;
-import org.jtalks.tests.jcommune.webdriver.action.Users;
-import org.jtalks.tests.jcommune.webdriver.entity.branch.Branch;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.CodeReview;
-import org.jtalks.tests.jcommune.webdriver.entity.topic.CodeReviewComment;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Poll;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
 import org.jtalks.tests.jcommune.webdriver.exceptions.PermissionsDeniedException;
-import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -25,143 +19,122 @@ import java.util.List;
 
 import static org.jtalks.tests.jcommune.utils.DriverMethodHelp.setCheckboxState;
 import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
-import static org.jtalks.tests.jcommune.webdriver.page.Pages.branchPage;
-import static org.jtalks.tests.jcommune.webdriver.page.Pages.topicPage;
-
 
 /**
  * @author masyan
+ * @author pancheshenko andrey
  */
 public class TopicPage {
     public static final String CR_COMMENT_EMPTY_ERROR = "(may not be empty\n)" +
             "|(Не может быть пустым\n)";
+
     public static final String EMPTY_BODY_ERROR = "(Size must be between 2 and 20000)" +
             "|(Размер должен быть между 2 и 20000)";
+
     public static final String SUBJECT_SIZE_ERROR = "(Length must be between 1 and 120 symbols\n)" +
             "|(Длина должна быть между 1 и 120 символами\n)";
+
     public static final String POLL_SUBJECT_EMPTY_ERROR = "(Poll title could not be blank if poll items arent blank)" +
             "|(Если заданы опции голосования, то заголовок голосования не может быть пустым)";
+
     public static final String POLL_SUBJECT_SIZE_ERROR = "(Size must be between 3 and 120)" +
             "|(Размер должен быть между 3 и 120)";
+
     public static final String POLL_OPTIONS_ERROR = "(Poll items could not be blank if poll title is not blank)" +
             "|(Если задан заголовок голосования, необходимо задать и опции голосования)";
+
     public static final String POLL_OPTIONS_NUMBER_ERROR = "(Options number should be 2 - 50)" +
             "|(Количество элементов должно быть 2 - 50)";
+
     public static final String POLL_OPTIONS_LENGTH_ERROR = "(Item length should be 1 - 50)" +
             "|(Длина опции голосования должна быть: 1 - 50)";
+
     public static final String POLL_DUPLICATES_ERROR = "(Poll items could not contain duplicates)" +
             "|(Опции голосования не могут содержать дубликаты)";
+
     public static final String CR_COMMENT_LENGTH_ERROR = "(Size must be between 1 and 5000\n)" +
             "|(Размер должен быть между 1 и 5000\n)";
+
+    private static final String postMessageSel = "//td[@class='post-content-td']/div";
+
+    private static final String editButtonSel = "edit_button";
+
+    public static final String backButtonOnEditFormSel = "//a[@class='back-btn']";
+    
     @FindBy(id = "subjectError")
     private WebElement subjectErrorMessage;
+
     @FindBy(id = "bodyText.errors")
     private WebElement bodyErrorMessage;
-    @FindBy(xpath = "//div[@id='add-comment-form']/div[@class='control-group error']/span[@class='help-inline']")
-    private WebElement codeReviewCommentBodyErrorMessage;
-    @FindBy(xpath = "//a[@class='back-btn']")
+
+    @FindBy(xpath = backButtonOnEditFormSel)
     private WebElement backButtonOnEditForm;
+
     @FindBy(xpath = "//table[@id='topics-table']/tbody/tr/td[contains(@class,'latest-by')]/a")
     private List<WebElement> topicLinksFromDateInLastColumn;
+
     @FindBy(xpath = "//table[@id='topics-table']/tbody/tr/td/a[contains(@href, '" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/topics/')]")
     private List<WebElement> topicLinksFromRecentActivity;
+
     @FindBy(xpath = "//span[@class='test-views']")
     private List<WebElement> amountsOfViewTopics;
+
     @FindBy(xpath = "//div[@class='forum_misc_info']/a")
     private List<WebElement> whoBrowsingTopic;
+
     @FindBy(id = "pollTitle")
     private WebElement topicsPollTitleField;
+
     @FindBy(id = "pollItems")
     private WebElement topicsPollItemsField;
+
     @FindBy(id = "datepicker")
     private WebElement topicsPollEndDateField;
+
     @FindBy(id = "multipleChecker")
     private WebElement topicsPollMultipleChecker;
+
     @FindBy(id = "topic.poll.title.errors")
     private WebElement pollTitleErrorMessage;
+
     @FindBy(id = "topic.poll.pollItems.errors")
     private WebElement pollItemsErrorMessage;
+
     @FindBy(xpath = "//*[@id='topics-table']/tbody/tr[last()]")
     private WebElement lastTopicLine;
-    @FindBy(xpath = "//div[@class='pagination pull-right forum-pagination']/ul/li/a")
-    private List<WebElement> topicsButtons;
-    @FindBy(xpath = "//div[@class='pagination pull-right forum-pagination']/ul/li[@class='active']/a")
-    private List<WebElement> activeTopicsButton;
+
     @FindBy(xpath = "//a[@href='" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/user' and not(@class='currentusername')]")
     private WebElement profileLink;
-    @FindBy(className = "new-topic-btn")
-    private WebElement newButton;
-    @FindBy(xpath = "//ul[@class='breadcrumb']/li[last()]")
-    private WebElement branchName;
-    @FindBy(className = "topic-types-dropdown")
-    private WebElement newTopicTypeToggle;
-    @FindBy(className = "new-code-review-btn")
-    private WebElement newCodeReviewButton;
-    @FindBy(xpath = "//ol[@class='linenums']/li")
-    private List<WebElement> codeReviewLines;
-    @FindBy(className = "review-container-content")
-    private WebElement codeReviewCommentBodyField;
-    @FindBy(className = "review-container-controls-ok")
-    private WebElement codeReviewCommentAddBtn;
-    @FindBy(className = "review-container-controls-cancel")
-    private WebElement codeReviewCommentCancelBtn;
+
     @FindBy(id = "sticked")
     private WebElement topicSticked;
+
     @FindBy(id = "announcement")
     private WebElement topicAnnouncement;
+
     @FindBy(id = "subject")
     private WebElement subjectField;
+
     @FindBy(id = "postBody")
     private WebElement mainBodyArea;
+
     @FindBy(id = "post")
     private WebElement postButton;
-    @FindBy(xpath = "//div[@id='branch-header']/h3")
-    private WebElement topicSubject;
-    @FindBy(xpath = "//div[@id='branch-header']/h1/a")
-    private WebElement topicSubjectAfterCreation;
-    @FindBy(xpath = "//div[@class = 'post']/table/tbody/tr/td[@class='post-content-td']/div")
-    private WebElement topicMessage;
-    @FindBy(xpath = "//table[@id='topics-table']/tbody/tr/td/a[contains(@href, '" + JCommuneSeleniumConfig.JCOMMUNE_CONTEXT_PATH + "/topics/')]")
-    private List<WebElement> topicsList;
-    private final WebDriver driver;
 
+    @FindBy(xpath = postMessageSel)
+    private WebElement postMessage;
+
+    @FindBy(className = editButtonSel)
+    private WebElement editButton;
+
+    @FindBy(id = "remove-entity-ok")
+    private WebElement deleteConfirmDialogButtonOk;
+
+    private final WebDriver driver;
 
     public TopicPage(WebDriver driver) {
         PageFactory.initElements(driver, this);
         this.driver = driver;
-    }
-
-    public void goToTopicPage() throws ValidationException {
-        Users.signUpAndSignIn();
-        Topic topic = new Topic("subject123", "New final test answer");
-        if (topic.getBranch() == null) {
-            Branch branch = new Branch(branchPage.getBranches().get(0).getText());
-            topic.withBranch(branch);
-        }
-        Branches.openBranch(topic.getBranch().getTitle());
-    }
-
-    public void goToTopicCreatePage() throws ValidationException {
-        topicPage.goToTopicPage();
-        topicPage.getNewButton().click();
-    }
-
-    public void goToReviewCreatePage() throws ValidationException {
-        topicPage.goToTopicPage();
-        topicPage.getNewTopicToggle().click();
-        topicPage.getNewCodeReviewButton().click();
-    }
-
-    @Step
-    public void clickCreateTopic() throws PermissionsDeniedException {
-        info("Clicking New Topic button");
-        try {
-            topicPage.getNewButton().click();
-        } catch (NoSuchElementException e) {
-            info("No such button found!");
-            throw new PermissionsDeniedException("Couldn't find New Topic button. Here is the page source: \n"
-                    + driver.getPageSource());
-        }
     }
 
     @Step
@@ -173,35 +146,32 @@ public class TopicPage {
         markTopicAsAnnouncement(topic.isAnnouncement());
     }
 
-    @Step
     private void fillTopicTitle(String topicTitle) {
         info("Fill topic title: [" + topicTitle + "]");
         this.subjectField.sendKeys(topicTitle);
     }
 
-    @Step
     private void fillTopicBody(String body) {
         info("Filling topic body: [" + StringUtils.left(body, 100) + "...]");
+        getMainBodyArea().clear();
         for (String token : Splitter.fixedLength(100).split(body)) {
-            this.mainBodyArea.sendKeys(token);
+            getMainBodyArea().sendKeys(token);
         }
     }
 
-    @Step
-    private void markTopicAsSticked(boolean topicIsSticked) throws PermissionsDeniedException {
-        if (topicIsSticked) {
+    private void markTopicAsSticked(boolean isTopicSticked) throws PermissionsDeniedException {
+        if (isTopicSticked) {
             info("Marking topic as sticked");
         } else {
             info("Marking topic as non-sticked");
         }
-        if (DriverMethodHelp.isElementDisplayedImmediately(driver, topicSticked)) {
-            setCheckboxState(topicSticked, topicIsSticked);
+        if (DriverMethodHelp.isElementDisplayedImmediately(driver, getTopicStickedCheckbox())) {
+            setCheckboxState(getTopicStickedCheckbox(), isTopicSticked);
         } else {
             info("Sticked checkbox is not on the page since user doesn't have permissions, so nothing to change");
         }
     }
 
-    @Step
     private void markTopicAsAnnouncement(boolean isAnnouncement) throws PermissionsDeniedException {
         if (isAnnouncement) {
             info("Marking topic as announcement");
@@ -219,14 +189,13 @@ public class TopicPage {
     public void fillPollSpecificFields(Poll poll) {
         if (poll != null) {
             info("Filling poll title: " + poll.getTitle());
-            topicsPollTitleField.sendKeys(poll.getTitle());
+            getTopicsPollTitleField().sendKeys(poll.getTitle());
             fillPollOptions(poll.getOptions());
             fillPollEndDate(poll.getEndDateAsString());
-            setCheckboxState(topicPage.getTopicsPollMultipleChecker(), poll.isMultipleAnswers());
+            setCheckboxState(getTopicsPollMultipleChecker(), poll.isMultipleAnswers());
         }
     }
 
-    @Step
     private void fillPollOptions(String[] pollOptions) {
         info("Filling poll options. Their number is: " + pollOptions.length);
         WebElement optionsField = getTopicPollItemsField();
@@ -236,11 +205,10 @@ public class TopicPage {
         }
     }
 
-    @Step
     private void fillPollEndDate(String endDate) {
         if (endDate != null) {
             info("Fill poll end date: " + endDate);
-            topicPage.getTopicsPollEndDateField().sendKeys(endDate);
+            getTopicsPollEndDateField().sendKeys(endDate);
         } else {
             info("Leaving poll end date empty");
         }
@@ -250,7 +218,7 @@ public class TopicPage {
     public void clickAnswerToTopicButton() throws PermissionsDeniedException {
         info("Clicking a button to post the topic/answer");
         try {
-            postButton.click();
+            getPostButton().click();
             info("The button was clicked");
         } catch (NoSuchElementException e) {
             info("Couldn't click the button, looks like the permissions are granted");
@@ -258,17 +226,11 @@ public class TopicPage {
         }
     }
 
-    public void clickCreateCodeReview() throws PermissionsDeniedException {
-        info("Clicking New Code Review Button");
-        try {
-            if (getNewTopicToggle() != null) {
-                newTopicTypeToggle.click();
-            }
-            newCodeReviewButton.click();
-        } catch (NoSuchElementException e) {
-            info("No such button found!");
-            throw new PermissionsDeniedException("Couldn't find New Code Review button. Here is the page source: \n"
-                    + driver.getPageSource());
+    public void editPostMessageBody(String newMessage) {
+        info("Editing post body: [" + StringUtils.left(newMessage, 100) + "...]");
+        getMainBodyArea().clear();
+        for (String token : Splitter.fixedLength(100).split(newMessage)) {
+            getMainBodyArea().sendKeys(token);
         }
     }
 
@@ -276,46 +238,10 @@ public class TopicPage {
         info("Filling code review title: [" + StringUtils.left(codeReview.getTitle(), 100) + "...]");
         getSubjectField().sendKeys(codeReview.getTitle());
         info("Filling code review body: [" + StringUtils.left(codeReview.getContent(), 100) + "...]");
-        this.mainBodyArea.sendKeys(codeReview.getContent());
+        getMainBodyArea().sendKeys(codeReview.getContent());
     }
-
-    public void clickLineInCodeReviewForComment(int lineNumber) throws PermissionsDeniedException, ValidationException {
-        info("Clicking a line #" + lineNumber + " to leave comment");
-        try {
-            codeReviewLines.get(lineNumber - 1).click();
-            info("The line was clicked");
-        } catch (IndexOutOfBoundsException e) {
-            info("The line doesn't exist");
-            throw new ValidationException("The commented line number exceeds the code review lines number");
-        }
-        try {
-            codeReviewCommentBodyField.clear(); // Checking whether this element exists
-        } catch (NoSuchElementException e) {
-            info("Clicking the line does nothing, looks like the permissions are not granted");
-            throw new PermissionsDeniedException("User does not have permissions to leave comments in branch");
-        }
-    }
-
-    public void fillCodeReviewCommentBody(CodeReviewComment codeReviewComment) {
-        info("Filling code review comment body: [" + StringUtils.left(codeReviewComment.getPostContent(), 100) + "...]");
-        codeReviewCommentBodyField.sendKeys(codeReviewComment.getPostContent());
-    }
-
-    public void clickAddCommentToCodeReviewButton() throws PermissionsDeniedException {
-        info("Clicking a button to add comment to code review");
-        try {
-            codeReviewCommentAddBtn.click();
-            info("The button was clicked");
-        } catch (NoSuchElementException e) {
-            info("Couldn't click the button, looks like the permissions are not granted");
-            throw new PermissionsDeniedException("User does not have permissions to leave comments in the branch");
-        }
-    }
-
+    
     //Getters
-    public WebElement getNewButton() {
-        return newButton;
-    }
 
     public WebElement getSubjectField() {
         return subjectField;
@@ -329,20 +255,16 @@ public class TopicPage {
         return postButton;
     }
 
-    public WebElement getTopicSubjectAfterCreation() {
-        return topicSubjectAfterCreation;
-    }
-
-    public List<WebElement> getTopicsList() {
-        return topicsList;
-    }
-
     public WebElement getSubjectErrorMessage() {
         return subjectErrorMessage;
     }
 
     public WebElement getBodyErrorMessage() {
         return bodyErrorMessage;
+    }
+
+    public WebElement getTopicStickedCheckbox() {
+        return topicSticked;
     }
 
     public WebElement getPollTitleErrorMessage() {
@@ -353,12 +275,12 @@ public class TopicPage {
         return pollItemsErrorMessage;
     }
 
-    public List<WebElement> getTopicsButtons() {
-        return topicsButtons;
-    }
-
     public WebElement getTopicPollItemsField() {
         return topicsPollItemsField;
+    }
+
+    public WebElement getTopicsPollTitleField() {
+        return topicsPollTitleField;
     }
 
     public WebElement getTopicsPollEndDateField() {
@@ -368,33 +290,4 @@ public class TopicPage {
     public WebElement getTopicsPollMultipleChecker() {
         return topicsPollMultipleChecker;
     }
-
-    public List<WebElement> getActiveTopicsButton() {
-        return activeTopicsButton;
-    }
-
-    public WebElement getNewTopicToggle() {
-        return newTopicTypeToggle;
-    }
-
-    public WebElement getNewCodeReviewButton() {
-        return newCodeReviewButton;
-    }
-
-    public WebElement getBranchName() {
-        return branchName;
-    }
-
-    public WebElement getCodeReviewCommentBodyField() {
-        return codeReviewCommentBodyField;
-    }
-
-    public List<WebElement> getCodeReviewLines() {
-        return codeReviewLines;
-    }
-
-    public WebElement getCodeReviewCommentBodyError() {
-        return codeReviewCommentBodyErrorMessage;
-    }
-
 }


### PR DESCRIPTION
 1. Changed name of the test in PagesW3CValidationTest according to the logic.
 2. Mail Parsing methods added to check mail for notifications
 3. Branches.openBranch() method change to check the current browsing in branch
 4. Branches.subscribe/unsubscribe() methods added
 5. Branches.unsubscribeIgnoringFail() method added that doesn't fail test in case of some complications
 6. Added notification methods that assert the existence/absence of branch/topic notification letters in mailbox
 7. Complete Topics.class refactoring
 8. Topics.createTopic() method now checks the current page for avoiding excessive main page loads
 9. Topics.postAnswer() method now opens required topic, posts answer, adds it to the post list of topic object and returns the newly created post
 10. Topics.editPost() method added that edits any desired post in the desired topic
 11. Topics.deleteTopic() method implemented
 12. Topics.moveTopic() methods implemented that move topic to the first branch in all branches list of to the desired branch using its title
 13. Topics.subscribe/unsubscribe() methods added
 14. Topics.openRequiredTopic() method added that would open required topic using gui as quickly as possible
 15. Topics.openTopicInCurrentBranch() method was fixed in the case when the desired topic is not on the first page of the branch
 16. Some goTo***() methods were moved from TopicPage.class to Topics.class
 17. Topics.assertIsSubscribed() method added that asserts the user's subscription
 18. Topics.leaveCodeReviewComment() method now navigates to desired topic before trying to leave comment in it
 19. Topics.editCodeReviewComment() method added
 20. Topics.editPost(CodeReview codeReview, Post postToEdit) method added that would throw unsupported operation error to handle this unsupported case
 21. Topics.deleteAnswer() method renamed into deletePost() and not yet implemented
 22. Topics.answerToTopic() method contents moved into postAnswer() method
 23. Topics.createCodeReview() void type method was removed (together with createNewCodeReview method)
 24. Users.logOutAndSignIn() method added that just combines two corresponding functions in one line
 25. CodeReview.class now correctly initializes comments list
 26. CodeReview.withBranch() method was added as override of corresponding superclass's method
 27. Topic.class redesign to separate getters
 28. Topic.addPost() method added that adds new post to the topic object
 29. Some fields inside User.class were changed to correspond their real default values
 30. Topics.openNextPage() is moved to the BranchPage.class
 31. Topics.findTopic() method is moved to the branchPage.class and renamed into findAndOpenTopic()
 32. BranchPage.class now describes the page that opens after branch name was clicked and topics list with topic creation buttons appear. This class was reworked and absorbed some methods from TopicPage.class
 33. MoveTopicEditor.class implemented that describes the corresponding dialog
 34. PostPage.class now describes the page that opens when topic title at the branch page was clicked and topic contents with all available posts are shown. This class was reworked and absorbed some methods from TopicPage.class
 35. SectionPage.class now describes the main forum page (excluding menus, external links, search bar, that are described in MainPage.class) where all visible sections shown for current user. This class was reworked and absorbed some methods from BranchPage.class
 36. Added fluent wait conditions in some cases where they are logical to exist
 37. Changed webElements usage inside page classes into usage of getters for holding one style in coding