### PR TITLE
JC-1959 Validation error text fix

### DIFF
--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/CodeReviewTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/CodeReviewTest.java
@@ -110,7 +110,7 @@ public class CodeReviewTest {
     }
 
     @Test(groups = "ui-tests", expectedExceptions = ValidationException.class,
-            expectedExceptionsMessageRegExp = TopicPage.CR_COMMENT_EMPTY_ERROR)
+            expectedExceptionsMessageRegExp = TopicPage.CR_COMMENT_LENGTH_ERROR)
     public void leaveEmptyCommentToCodeReview_ShouldFail() throws Exception {
         Users.signUpAndSignIn();
         CodeReview codeReview = new CodeReview();


### PR DESCRIPTION
Validation error text 'may not be empty' would change into 'Size must be between
N and K'.