### PR TITLE
Update rules of naming of test methods

### DIFF
--- a/functional-tests-jcommune/README.md
+++ b/functional-tests-jcommune/README.md
@@ -1,6 +1,6 @@
 ####Test Methods:
 * All test cases are kept in separate test methods. To simplify future debugging we're not using `@DataProvider`
-* Test methods should be named \[action\]_\[condition\]_\[expected result\]_\[TestCaseId\],
-* e.g.: `signIn_withoutEnteringData_shouldFail_TC1234()`.
+* Test methods should be named \[action\]_\[condition\]_\[expected result\],
+* e.g.: `signIn_withoutEnteringData_shouldFail`.
 * Methods should be marked with groups `@Test(groups = {"sanity", "primary", "regression"})` depending on the type of
  test. These groups are going to be run separately.


### PR DESCRIPTION
- remove links to a number of the manual test case 
  from a name of the test method