### PR TITLE
#JC-1739 prepare clasees and methods required for automation Draft story

### DIFF
--- a/functional-tests-jcommune/README.md
+++ b/functional-tests-jcommune/README.md
@@ -1,6 +1,6 @@
 ####Test Methods:
 * All test cases are kept in separate test methods. To simplify future debugging we're not using `@DataProvider`
-* Test methods should be named \[action\]_\[condition\]_\[expected result\]_\[TestCaseId\],
-* e.g.: `signIn_withoutEnteringData_shouldFail_TC1234()`.
+* Test methods should be named \[action\]_\[condition\]_\[expected result\],
+* e.g.: `signIn_withoutEnteringData_shouldFail`.
 * Methods should be marked with groups `@Test(groups = {"sanity", "primary", "regression"})` depending on the type of
  test. These groups are going to be run separately.

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -38,4 +38,15 @@ public class TopicDraftTest {
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_MoveFocus_ShouldSave() {
+        Users.signUpAndSignIn();
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+
+        Draft draft = Topics.typeAnswer(createdTopic).loseFocus();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -91,4 +91,15 @@ public class TopicDraftTest {
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_ContentCopyPastLoseFocus_ShouldSave() {
+        Users.signUpAndSignIn();
+
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+        Draft draft = Topics.pasteAnswer(createdTopic).loseFocus();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -21,6 +21,9 @@ import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
  */
 public class TopicDraftTest {
 
+    private final String BRANCH_BICYCLE = "Bicycle";
+    private final String BRANCH_EUROPE = "Europe";
+
     @BeforeMethod(alwaysRun = true)
     @Parameters({"appUrl"})
     public void setupCase(String appUrl) throws ValidationException {
@@ -118,5 +121,18 @@ public class TopicDraftTest {
         Draft secondDraft = Topics.pasteAnswer(createdTopic).loseFocus();
 
         assertThat(secondDraft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_DifferentDraftInDifferentBranchesLoseFocus_ShouldSave() {
+        Users.signUpAndSignIn();
+
+        Topic topicFirst = Topics.createTopic(new Topic().withBranch(BRANCH_EUROPE));
+        Draft draftFirst = Topics.typeAnswer(topicFirst).loseFocus();
+        assertThat(draftFirst.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+
+        Topic topicSecond = Topics.createTopic(new Topic().withBranch(BRANCH_BICYCLE));
+        Draft draftSecond = Topics.typeAnswer(topicSecond).loseFocus();
+        assertThat(draftSecond.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -78,4 +78,17 @@ public class TopicDraftTest {
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_ContentWith2SymbLoseFocus_ShouldSave() {
+        int quantitySymb = 2;
+
+        Users.signUpAndSignIn();
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+
+        Draft draft = Topics.typeAnswerCustomLength(createdTopic, quantitySymb).loseFocus();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -5,6 +5,7 @@ import org.jtalks.tests.jcommune.webdriver.action.Topics;
 import org.jtalks.tests.jcommune.webdriver.action.Users;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Draft;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
+import org.jtalks.tests.jcommune.webdriver.entity.user.User;
 import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Parameters;
@@ -46,6 +47,20 @@ public class TopicDraftTest {
         Topic createdTopic = Topics.createTopic(topic);
 
         Draft draft = Topics.typeAnswer(createdTopic).loseFocus();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_Logout_ShouldSave() {
+        User draftCreator = Users.signUpAndSignIn();
+
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+        Draft draft = Topics.typeAnswer(createdTopic);
+
+        Users.logOutAndSignIn(draftCreator);
+        Topics.openRequiredTopic(createdTopic);
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -102,4 +102,21 @@ public class TopicDraftTest {
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_DifferentUsersSameTopicLoseFocus_ShouldSaveBoth() {
+        Users.signUpAndSignIn();
+
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+        Draft firstDraft = Topics.pasteAnswer(createdTopic).loseFocus();
+
+        assertThat(firstDraft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+
+        Users.logoutSignUpAndSignIn();
+        Topics.openRequiredTopic(createdTopic);
+        Draft secondDraft = Topics.pasteAnswer(createdTopic).loseFocus();
+
+        assertThat(secondDraft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -135,4 +135,19 @@ public class TopicDraftTest {
         Draft draftSecond = Topics.typeAnswer(topicSecond).loseFocus();
         assertThat(draftSecond.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void presenceOfDraft_LoseFocusLogoutDeleteCookies_ShouldBePresent() {
+        User user = Users.signUpAndSignIn();
+
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+        Draft draft = Topics.typeAnswer(createdTopic).loseFocus();
+
+        Users.logoutAndDeleteAllCookies();
+        Users.signIn(user);
+        Topics.openRequiredTopic(createdTopic);
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -1,0 +1,41 @@
+package org.jtalks.tests.jcommune;
+
+import org.jtalks.tests.jcommune.webdriver.action.Pages;
+import org.jtalks.tests.jcommune.webdriver.action.Topics;
+import org.jtalks.tests.jcommune.webdriver.action.Users;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.Draft;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
+import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.mainPage;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+
+/**
+ * Created by @baranov.r.p
+ */
+public class TopicDraftTest {
+
+    @BeforeMethod(alwaysRun = true)
+    @Parameters({"appUrl"})
+    public void setupCase(String appUrl) throws ValidationException {
+        driver.get(appUrl);
+        mainPage.logOutIfLoggedIn(driver);
+    }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_OpenAndCloseNewTab_ShouldSave() {
+        Users.signUpAndSignIn();
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+
+        Draft draft = Topics.typeAnswer(createdTopic);
+        Pages.openAndCloseNewTab();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
+}

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -64,4 +64,18 @@ public class TopicDraftTest {
 
         assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
     }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void remainDraft_LoseFocusCloseTopic_ShouldRemain() {
+        // user with permissions to close topic
+        Users.signIn(User.admin());
+
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+        Draft draft = Topics.typeAnswer(createdTopic).loseFocus();
+
+        Topics.findAndCloseTopic(topic);
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
 }

--- a/functional-tests-jcommune/src/test/resources/testng.xml
+++ b/functional-tests-jcommune/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
       <class name="org.jtalks.tests.jcommune.SignInTest"/>
       <class name="org.jtalks.tests.jcommune.ProfileTest"/>
       <class name="org.jtalks.tests.jcommune.TopicTest"/>
+      <class name="org.jtalks.tests.jcommune.TopicDraftTest"/>
       <class name="org.jtalks.tests.jcommune.ExternalLinksTest"/>
       <class name="org.jtalks.tests.jcommune.CheckMailCounterTest"/>
       <class name="org.jtalks.tests.jcommune.AdministrationTest"/>
@@ -50,6 +51,7 @@
       <class name="org.jtalks.tests.jcommune.SignInTest"/>
       <class name="org.jtalks.tests.jcommune.ProfileTest"/>
       <class name="org.jtalks.tests.jcommune.TopicTest"/>
+      <class name="org.jtalks.tests.jcommune.TopicDraftTest"/>
       <class name="org.jtalks.tests.jcommune.ExternalLinksTest"/>
       <class name="org.jtalks.tests.jcommune.AdministrationTest"/>
       <class name="org.jtalks.tests.jcommune.CodeReviewTest"/>

--- a/jcommune-webdriver/pom.xml
+++ b/jcommune-webdriver/pom.xml
@@ -62,6 +62,11 @@
           <artifactId>spring-web</artifactId>
           <version>3.1.0.RELEASE</version>
      </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.1.0</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/utils/Utils.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/utils/Utils.java
@@ -1,0 +1,21 @@
+package org.jtalks.tests.jcommune.utils;
+
+import org.openqa.selenium.Keys;
+
+import java.awt.datatransfer.StringSelection;
+
+import static java.awt.Toolkit.getDefaultToolkit;
+import static org.openqa.selenium.Keys.chord;
+
+/**
+ * @author baranov.r.p
+ */
+public class Utils {
+    public static final String PASTE_CHORD = chord(Keys.CONTROL + "v");
+    public static final String OPEN_NEW_TAB_CHORD = chord(Keys.CONTROL + "t");
+    public static final String CLOSE_CURRENT_TAB_CHORD = chord(Keys.CONTROL + "w");
+
+    public static void setTextToClipboard(String text) {
+        getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(text), null);
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/JCommuneSeleniumConfig.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/JCommuneSeleniumConfig.java
@@ -2,6 +2,7 @@ package org.jtalks.tests.jcommune.webdriver;
 
 import org.jtalks.tests.jcommune.webdriver.page.Pages;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.CapabilityType;
@@ -33,6 +34,7 @@ public class JCommuneSeleniumConfig {
     public static WebDriver driver = null;
     public static String webdriverType;
     private static String appUrl;
+    private static JavascriptExecutor js = null;
 
     public static Capabilities getCapabilities() {
         return ((RemoteWebDriver) driver).getCapabilities();
@@ -66,6 +68,7 @@ public class JCommuneSeleniumConfig {
         LOGGER.info("Selenium WebDriver URL: [{}]", seleniumUrl);
         driver = new RemoteWebDriver(new URL(seleniumUrl), capabilities);
         driver.manage().timeouts().implicitlyWait(SELENIUM_TIMEOUT_SEC, TimeUnit.SECONDS);
+        js = (JavascriptExecutor) driver;
     }
 
     private String getOs() {
@@ -120,5 +123,9 @@ public class JCommuneSeleniumConfig {
 
     public static String getAppUrl() {
         return appUrl;
+    }
+
+    public static JavascriptExecutor getJs() {
+        return js;
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Pages.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Pages.java
@@ -1,0 +1,33 @@
+package org.jtalks.tests.jcommune.webdriver.action;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.jtalks.tests.jcommune.utils.Utils.CLOSE_CURRENT_TAB_CHORD;
+import static org.jtalks.tests.jcommune.utils.Utils.OPEN_NEW_TAB_CHORD;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.getJs;
+
+/**
+ * @author baranov.r.p
+ */
+public class Pages {
+
+    @Step
+    public static void refreshPage() {
+        driver.navigate().refresh();
+    }
+
+    @Step
+    public static void scrollToEl(WebElement el) {
+        getJs().executeScript("arguments[0].scrollIntoView(false);", el);
+    }
+
+    @Step
+    public static void openAndCloseNewTab() {
+        By bodyTag = By.tagName("body");
+        driver.findElement(bodyTag).sendKeys(OPEN_NEW_TAB_CHORD);
+        driver.findElement(bodyTag).sendKeys(CLOSE_CURRENT_TAB_CHORD);
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Users.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Users.java
@@ -38,7 +38,10 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
 import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
-import static org.jtalks.tests.jcommune.webdriver.page.Pages.*;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.mainPage;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.profilePage;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.signInPage;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.signUpPage;
 
 /**
  * Contain user actions like sign in, sign out etc.
@@ -83,6 +86,18 @@ public class Users {
     @Step
     public static void logout() {
         mainPage.clickLogout();
+    }
+
+    @Step
+    public static void logoutSignUpAndSignIn() {
+        logout();
+        signUpAndSignIn();
+    }
+
+    @Step
+    public static void logoutAndDeleteAllCookies() {
+        mainPage.clickLogout();
+        driver.manage().deleteAllCookies();
     }
 
     public static User signUpAndSignIn() {

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Draft.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Draft.java
@@ -1,0 +1,34 @@
+package org.jtalks.tests.jcommune.webdriver.entity.topic;
+import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+
+/**
+ * @author baranov.r.p
+ */
+public class Draft extends Post {
+
+    public Draft(String postContent) {
+        super(postContent);
+    }
+
+    @Step
+    public Draft loseFocus() {
+        info("Trying to set focus on link post button");
+        postPage.setFocusOnPostLinkButton();
+        return this;
+    }
+
+    public void publish() {
+        // publish draft as post/answer
+    }
+
+    public void deleteContent() {
+        // delete content by pressing Backspace
+    }
+
+    public void editContent(int quantitySymbRemain) {
+        // remain quantity of symb that specified in parameters
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
 import static org.jtalks.tests.jcommune.webdriver.page.Pages.moveTopicEditor;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+import static org.jtalks.tests.jcommune.webdriver.action.Pages.scrollToEl;
 
 /**
  * @author masyan
@@ -218,6 +220,28 @@ public class PostPage {
     @FindBy(xpath = codeReviewCommentBodyErrorMessageSel)
     private WebElement codeReviewCommentBodyErrorMessage;
 
+    @FindBy(tagName = "textarea")
+    private WebElement textareaEditor;
+
+    @FindBy(id = "postDto")
+    private WebElement postDto;
+
+    @FindBy(id = "counter")
+    private WebElement draftCounter;
+
+    // space symbol is used for localization compatibility, in any language counter message will have spaces
+    @FindBy(xpath = "//span[@id='counter' and contains(text(),' ')]")
+    private WebElement draftCounterActive;
+
+    @FindBy(className = "postLink")
+    private WebElement postLink;
+
+    @FindBy(xpath = "//a[contains(@class, 'open_topic') and contains(@href, 'close')]")
+    private WebElement buttonCloseTopic;
+
+    @FindBy(xpath = "//a[contains(@class, 'open_topic') and contains(@href, 'open')]")
+    private WebElement buttonReopenTopic;
+
     private WebDriver driver;
 
     public PostPage(WebDriver driver) {
@@ -391,6 +415,47 @@ public class PostPage {
         return false;
     }
 
+    public void setFocusOnPostLinkButton() {
+        // move focus outside of textarea
+        getPostLinkButton().sendKeys("");
+        info("Focus set on edit post button");
+    }
+
+    public String scrollDownAndFindDraftCountMessage() {
+        // scroll page to the bottom of post editor,
+        // guarantee that draft counter message will be visible for driver
+        scrollToEl(getPostDto());
+        info("Trying to find draft counter message");
+        return getDraftCounterActiveSpan().getText();
+    }
+
+    public String reloadAndFindDraftContent() {
+        checkCounter();
+        // reload page to get confidence that draft really saved
+        org.jtalks.tests.jcommune.webdriver.action.Pages.refreshPage();
+        info("Trying to find draft content");
+        return getTextareaEditor().getAttribute("value");
+    }
+
+    public boolean checkCounter() {
+        try {
+            postPage.scrollDownAndFindDraftCountMessage();
+        } catch (Exception e) {
+            throw new RuntimeException("Draft was not created", e);
+        }
+        return true;
+    }
+
+    public void clickButtonCloseTopic() {
+        info("Clicking button close topic ...");
+        getButtonCloseTopic().click();
+    }
+
+    public WebElement findButtonReopenTopic() {
+        info("Find Reopen button ...");
+        return getButtonReopenTopic();
+    }
+
     //Getters
 
     public WebElement getTopicTitle() {
@@ -549,5 +614,33 @@ public class PostPage {
 
     public WebElement getCRCommentBodyErrorMessage() {
         return codeReviewCommentBodyErrorMessage;
+    }
+
+    public WebElement getPostDto() {
+        return postDto;
+    }
+
+    public WebElement getDraftCounter() {
+        return draftCounter;
+    }
+
+    public WebElement getDraftCounterActiveSpan() {
+        return draftCounterActive;
+    }
+
+    public WebElement getTextareaEditor() {
+        return textareaEditor;
+    }
+
+    public WebElement getPostLinkButton() {
+        return postLink;
+    }
+
+    public WebElement getButtonCloseTopic() {
+        return buttonCloseTopic;
+    }
+
+    public WebElement getButtonReopenTopic() {
+        return buttonReopenTopic;
     }
 }


### PR DESCRIPTION
* update rules of naming of test methods:
 * remove links to a number of the manual test case from a name of the test method; 
* add assertj lib for flexible and more readable assertions; 
* inject JavascriptExecutor for an execution of javascript's snippets; 
* add Utils class
 * add hotkeys chords (paste, new tab, close tab);
 * implement possibility to put text to system clipboard; 
* add class with actions that can be performed on any page:
 * add method for scroll to element (gives a confidence that element is visible);
 * add method for refresh page without usage the cache;
* add method for open and close new tab; 
* add webElems, getters and method required to interact with drafts:
 * scroll down and find draft counter message;
 * set focuse outside text field;
 * reload and find content of draft;
 * check presence of counter message;
 * click on button close topic;
 * find button re-open topic; 
* add Steps for User:
 * possibility to clear all cookies after logout;
 * chain for logout, signup and signin;
* add Draft entity:
 * add method lose focus;
Next Step: add Steps in topic to create drats, add Tests for drafts
 * add required stubs;