### PR TITLE
#JC-1739 add test create draft by moving focus

### DIFF
--- a/functional-tests-jcommune/README.md
+++ b/functional-tests-jcommune/README.md
@@ -1,6 +1,6 @@
 ####Test Methods:
 * All test cases are kept in separate test methods. To simplify future debugging we're not using `@DataProvider`
-* Test methods should be named \[action\]_\[condition\]_\[expected result\]_\[TestCaseId\],
-* e.g.: `signIn_withoutEnteringData_shouldFail_TC1234()`.
+* Test methods should be named \[action\]_\[condition\]_\[expected result\],
+* e.g.: `signIn_withoutEnteringData_shouldFail`.
 * Methods should be marked with groups `@Test(groups = {"sanity", "primary", "regression"})` depending on the type of
  test. These groups are going to be run separately.

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -26,7 +26,7 @@ public class TopicDraftTest {
         mainPage.logOutIfLoggedIn(driver);
     }
 
-    @Test(groups = {"ui-tests", "primary"})
+    @Test(groups = {"primary"})
     public void autoSaveDraft_MoveFocus_ShouldSave() {
         Users.signUpAndSignIn();
         Topic topic = new Topic();

--- a/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
+++ b/functional-tests-jcommune/src/test/java/org/jtalks/tests/jcommune/TopicDraftTest.java
@@ -1,0 +1,39 @@
+package org.jtalks.tests.jcommune;
+
+import org.jtalks.tests.jcommune.webdriver.action.Topics;
+import org.jtalks.tests.jcommune.webdriver.action.Users;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.Draft;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
+import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.mainPage;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+
+/**
+ * Created by @baranov.r.p
+ */
+public class TopicDraftTest {
+
+    @BeforeMethod(alwaysRun = true)
+    @Parameters({"appUrl"})
+    public void setupCase(String appUrl) throws ValidationException {
+        driver.get(appUrl);
+        mainPage.logOutIfLoggedIn(driver);
+    }
+
+    @Test(groups = {"ui-tests", "primary"})
+    public void autoSaveDraft_MoveFocus_ShouldSave() {
+        Users.signUpAndSignIn();
+        Topic topic = new Topic();
+        Topic createdTopic = Topics.createTopic(topic);
+
+        Draft draft = Topics.typeAnswer(createdTopic).loseFocus();
+
+        assertThat(draft.getPostContent()).isEqualTo(postPage.reloadAndFindDraftContent());
+    }
+}

--- a/functional-tests-jcommune/src/test/resources/testng.xml
+++ b/functional-tests-jcommune/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
       <class name="org.jtalks.tests.jcommune.SignInTest"/>
       <class name="org.jtalks.tests.jcommune.ProfileTest"/>
       <class name="org.jtalks.tests.jcommune.TopicTest"/>
+      <class name="org.jtalks.tests.jcommune.TopicDraftTest"/>
       <class name="org.jtalks.tests.jcommune.ExternalLinksTest"/>
       <class name="org.jtalks.tests.jcommune.CheckMailCounterTest"/>
       <class name="org.jtalks.tests.jcommune.AdministrationTest"/>
@@ -50,6 +51,7 @@
       <class name="org.jtalks.tests.jcommune.SignInTest"/>
       <class name="org.jtalks.tests.jcommune.ProfileTest"/>
       <class name="org.jtalks.tests.jcommune.TopicTest"/>
+      <class name="org.jtalks.tests.jcommune.TopicDraftTest"/>
       <class name="org.jtalks.tests.jcommune.ExternalLinksTest"/>
       <class name="org.jtalks.tests.jcommune.AdministrationTest"/>
       <class name="org.jtalks.tests.jcommune.CodeReviewTest"/>

--- a/jcommune-webdriver/pom.xml
+++ b/jcommune-webdriver/pom.xml
@@ -62,6 +62,11 @@
           <artifactId>spring-web</artifactId>
           <version>3.1.0.RELEASE</version>
      </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.1.0</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/JCommuneSeleniumConfig.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/JCommuneSeleniumConfig.java
@@ -2,6 +2,7 @@ package org.jtalks.tests.jcommune.webdriver;
 
 import org.jtalks.tests.jcommune.webdriver.page.Pages;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.CapabilityType;
@@ -33,6 +34,7 @@ public class JCommuneSeleniumConfig {
     public static WebDriver driver = null;
     public static String webdriverType;
     private static String appUrl;
+    private static JavascriptExecutor js = null;
 
     public static Capabilities getCapabilities() {
         return ((RemoteWebDriver) driver).getCapabilities();
@@ -66,6 +68,7 @@ public class JCommuneSeleniumConfig {
         LOGGER.info("Selenium WebDriver URL: [{}]", seleniumUrl);
         driver = new RemoteWebDriver(new URL(seleniumUrl), capabilities);
         driver.manage().timeouts().implicitlyWait(SELENIUM_TIMEOUT_SEC, TimeUnit.SECONDS);
+        js = (JavascriptExecutor) driver;
     }
 
     private String getOs() {
@@ -120,5 +123,9 @@ public class JCommuneSeleniumConfig {
 
     public static String getAppUrl() {
         return appUrl;
+    }
+
+    public static JavascriptExecutor getJs() {
+        return js;
     }
 }

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Pages.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Pages.java
@@ -1,0 +1,23 @@
+package org.jtalks.tests.jcommune.webdriver.action;
+
+import org.openqa.selenium.WebElement;
+import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.getJs;
+
+/**
+ * @author baranov.r.p
+ */
+public class Pages {
+
+    @Step
+    public static void refreshPage() {
+        driver.navigate().refresh();
+    }
+
+    @Step
+    public static void scrollToEl(WebElement el) {
+        getJs().executeScript("arguments[0].scrollIntoView(false);", el);
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Topics.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/action/Topics.java
@@ -20,6 +20,7 @@ import org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig;
 import org.jtalks.tests.jcommune.webdriver.entity.branch.Branch;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.CodeReview;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.CodeReviewComment;
+import org.jtalks.tests.jcommune.webdriver.entity.topic.Draft;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Post;
 import org.jtalks.tests.jcommune.webdriver.entity.topic.Topic;
 import org.jtalks.tests.jcommune.webdriver.entity.user.User;
@@ -27,8 +28,6 @@ import org.jtalks.tests.jcommune.webdriver.exceptions.CouldNotOpenPageException;
 import org.jtalks.tests.jcommune.webdriver.exceptions.PermissionsDeniedException;
 import org.jtalks.tests.jcommune.webdriver.exceptions.TimeoutException;
 import org.jtalks.tests.jcommune.webdriver.exceptions.ValidationException;
-import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
-
 import org.jtalks.tests.jcommune.webdriver.page.PostPage;
 import org.jtalks.tests.jcommune.webdriver.page.TopicPage;
 import org.openqa.selenium.By;
@@ -42,9 +41,10 @@ import ru.yandex.qatools.allure.annotations.Step;
 import java.util.List;
 
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
-import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
-import static org.jtalks.tests.jcommune.webdriver.page.Pages.*;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+import static org.jtalks.tests.jcommune.webdriver.JCommuneSeleniumConfig.driver;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.*;
 
 /**
  * Contain topic actions like creating, deleting etc.
@@ -99,6 +99,18 @@ public class Topics {
 
         info("Answer to topic [" + topic.getTitle() + "] was left");
         return newPost;
+    }
+
+    @Step
+    public static Draft typeAnswer(Topic topic) throws PermissionsDeniedException, CouldNotOpenPageException {
+        openRequiredTopic(topic);
+
+        Post newDraft = new Draft(randomAlphanumeric(200));
+        topic.addPost(newDraft);
+        postPage.getMessageField().sendKeys(newDraft.getPostContent());
+
+        info("Draft in topic [" + topic.getTitle() + "] saving ...");
+        return (Draft) newDraft;
     }
 
     @Step

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Draft.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/entity/topic/Draft.java
@@ -1,0 +1,22 @@
+package org.jtalks.tests.jcommune.webdriver.entity.topic;
+import ru.yandex.qatools.allure.annotations.Step;
+
+import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+
+/**
+ * @author baranov.r.p
+ */
+public class Draft extends Post {
+
+    public Draft(String postContent) {
+        super(postContent);
+    }
+
+    @Step
+    public Draft loseFocus() {
+        info("Trying to set focus on link post button");
+        postPage.setFocusOnPostLinkButton();
+        return this;
+    }
+}

--- a/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
+++ b/jcommune-webdriver/src/main/java/org/jtalks/tests/jcommune/webdriver/page/PostPage.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import static org.jtalks.tests.jcommune.utils.ReportNgLogger.info;
 import static org.jtalks.tests.jcommune.webdriver.page.Pages.moveTopicEditor;
+import static org.jtalks.tests.jcommune.webdriver.page.Pages.postPage;
+import static org.jtalks.tests.jcommune.webdriver.action.Pages.scrollToEl;
 
 /**
  * @author masyan
@@ -218,6 +220,19 @@ public class PostPage {
     @FindBy(xpath = codeReviewCommentBodyErrorMessageSel)
     private WebElement codeReviewCommentBodyErrorMessage;
 
+    @FindBy(tagName = "textarea")
+    private WebElement textareaEditor;
+
+    @FindBy(id = "postDto")
+    private WebElement postDto;
+
+    // space symbol is used for localization compatibility, in any language counter message will have spaces
+    @FindBy(xpath = "//span[@id='counter' and contains(text(),' ')]")
+    private WebElement draftCounterActive;
+
+    @FindBy(className = "postLink")
+    private WebElement postLink;
+
     private WebDriver driver;
 
     public PostPage(WebDriver driver) {
@@ -391,6 +406,37 @@ public class PostPage {
         return false;
     }
 
+    public void setFocusOnPostLinkButton() {
+        // move focus outside of textarea
+        getPostLinkButton().sendKeys("");
+        info("Focus set on edit post button");
+    }
+
+    public String scrollDownAndFindDraftCountMessage() {
+        // scroll page to the bottom of post editor,
+        // guarantee that draft counter message will be visible for driver
+        scrollToEl(getPostDto());
+        info("Trying to find draft counter message");
+        return getDraftCounterActiveSpan().getText();
+    }
+
+    public String reloadAndFindDraftContent() {
+        checkCounter();
+        // reload page to get confidence that draft really saved
+        org.jtalks.tests.jcommune.webdriver.action.Pages.refreshPage();
+        info("Trying to find draft content");
+        return getTextareaEditor().getAttribute("value");
+    }
+
+    public boolean checkCounter() {
+        try {
+            postPage.scrollDownAndFindDraftCountMessage();
+        } catch (Exception e) {
+            throw new RuntimeException("Draft was not created", e);
+        }
+        return true;
+    }
+
     //Getters
 
     public WebElement getTopicTitle() {
@@ -549,5 +595,21 @@ public class PostPage {
 
     public WebElement getCRCommentBodyErrorMessage() {
         return codeReviewCommentBodyErrorMessage;
+    }
+
+    public WebElement getPostDto() {
+        return postDto;
+    }
+
+    public WebElement getDraftCounterActiveSpan() {
+        return draftCounterActive;
+    }
+
+    public WebElement getTextareaEditor() {
+        return textareaEditor;
+    }
+
+    public WebElement getPostLinkButton() {
+        return postLink;
     }
 }


### PR DESCRIPTION
- update rules of naming of test methods
 - remove number of a manual test case from a name of the test method
- add assertj lib for flexible and more readable assertions	
- inject JavascriptExecutor for an execution of javascript's snippets
- add class with actions that can be performed on any page
 - add method for scroll to element (gives a confidence that element is visible);
 - add method for refresh page without usage the cache;
- add webElems, getters and method required to interact with drafts
 - scroll down and find draft counter message
 - set focus outside text field
 - reload and find content of draft
 - check presence of counter message
- add draft entity, add method lose focus;	
- add steps to create drat by type text with default length;
- add test create draft by moving focus
- add Draft Test Suit to primary and regression pack